### PR TITLE
[WIP] flaskoidc v0.1.0b4 with offline validate

### DIFF
--- a/public.Dockerfile
+++ b/public.Dockerfile
@@ -23,12 +23,16 @@ CMD [ "python3",  "amundsen_application/wsgi.py" ]
 
 FROM base as oidc-release
 
+RUN pip3 install https://github.com/jornh/flaskoidc/archive/b08f659a98886070d60c9d8fef869a09476de47e.zip
+
 RUN pip3 install .[oidc]
 ENV FRONTEND_SVC_CONFIG_MODULE_CLASS amundsen_application.oidc_config.OidcConfig
 ENV APP_WRAPPER flaskoidc
 ENV APP_WRAPPER_CLASS FlaskOIDC
 ENV FLASK_OIDC_WHITELISTED_ENDPOINTS status,healthcheck,health
 ENV FLASK_OIDC_SQLALCHEMY_DATABASE_URI sqlite:///sessions.db
+ENV FLASK_OIDC_CLOCK_SKEW 3000
+ENV FLASK_OIDC_RESOURCE_SERVER_VALIDATION_MODE offline
 
 # You will need to set these environment variables in order to use the oidc image
 # FLASK_OIDC_CLIENT_SECRETS - a path to a client_secrets.json file

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,14 @@ def is_npm_installed() -> bool:
 def build_js() -> None:
     if not is_npm_installed():
         logging.error('npm must be available')
+        return
 
     try:
         subprocess.check_call(['npm install'], cwd=PACKAGE_DIR, shell=True)
         subprocess.check_call(['npm run build'], cwd=PACKAGE_DIR, shell=True)
     except Exception as e:
-        logging.warn('Installation of npm dependencies failed')
-        logging.warn(str(e))
+        logging.warning('Installation of npm dependencies failed')
+        logging.warning(str(e))
 
 
 build_js()
@@ -49,7 +50,7 @@ setup(
     dependency_links=[],
     install_requires=requirements,
     extras_require={
-        'oidc': ['flaskoidc==0.0.2']
+        'oidc': ['flaskoidc==0.1.0b4']
     },
     python_requires=">=3.6",
     entry_points="""


### PR DESCRIPTION
### Summary of Changes

This gives offline OIDC validation which enables us to do Auth with Azure AD and Google - possibly other providers. In addition it reduces load on auth servers, including the already supported Okta and KeyCloak providers.

This PR stacks on top of https://github.com/jornh/flaskoidc/tree/b08f659a98886070d60c9d8fef869a09476de47e and under https://github.com/lyft/amundsen/pull/354. 

Merge of this PR awaits regression testing that `flask_oidc_ex` introduction doesn't break anything for KeyCloak and Okta OIDC users. **Please help with testing if you're interested in better OIDC support in Amundsen**

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
