### PR TITLE
feat[WIP]: redirect dashboard group to search filter

### DIFF
--- a/amundsen_application/static/js/components/DashboardPage/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/index.tsx
@@ -47,6 +47,8 @@ import { NO_TIMESTAMP_TEXT } from 'components/constants';
 import ImagePreview from './ImagePreview';
 
 import './styles.scss';
+import { UpdateSearchStateRequest } from 'ducks/search/types';
+import { updateSearchState } from 'ducks/search/reducer';
 
 interface DashboardPageState {
   uri: string;
@@ -68,6 +70,7 @@ export interface DispatchFromProps {
     searchIndex?: string;
     source?: string;
   }) => GetDashboardRequest;
+  searchDashboardGroup: (dashboardGroup: string) => UpdateSearchStateRequest;
 }
 
 export type DashboardPageProps = RouteComponentProps<MatchProps> &
@@ -102,6 +105,15 @@ export class DashboardPage extends React.Component<
       this.props.getDashboard({ source, uri, searchIndex: index });
     }
   }
+
+  onClick = (e) => {
+    const dashboardGroup = this.props.dashboard.group_name;
+    logClick(e, {
+      target_type: 'dashboard_group',
+      label: dashboardGroup,
+    });
+    this.props.searchDashboardGroup(dashboardGroup);
+  };
 
   mapStatusToStyle = (status: string): BadgeStyle => {
     if (status === LAST_RUN_SUCCEEDED) {
@@ -344,8 +356,19 @@ export const mapStateToProps = (state: GlobalState) => {
   };
 };
 
+export function searchDashboardGroup(
+  dashboardGroup: string
+): updateSearchState {
+  return {
+    filters: {
+      [ResourceType.dashboard]: { group: dashboardGroup },
+    },
+    submitSearch: true,
+  };
+}
+
 export const mapDispatchToProps = (dispatch: any) => {
-  return bindActionCreators({ getDashboard }, dispatch);
+  return bindActionCreators({ getDashboard, searchDashboardGroup }, dispatch);
 };
 
 export default connect<StateFromProps, DispatchFromProps>(


### PR DESCRIPTION
### Summary of Changes

WIP: when user clicks dashboard group, it will redirect to the search filter page.

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
