### PR TITLE
feat: Wiring announcements block on Homepage

### DIFF
--- a/amundsen_application/api/announcements/v0.py
+++ b/amundsen_application/api/announcements/v0.py
@@ -28,6 +28,11 @@ announcements_blueprint = Blueprint('announcements', __name__, url_prefix='/api/
 def get_announcements() -> Response:
     global ANNOUNCEMENT_CLIENT_INSTANCE
 
+    # Testing Code, remove at the end
+    payload = jsonify({"msg":"Success","posts":[{"date":"October 31, 2018","html_content":"Tables under the following schemas are now available in Amundsen! \ud83c\udf89\n\n<ul>\n<li>basemap</li>\n<li>driver_engagement</li>\n<li>enterprise</li>\n<li>experimentation</li>\n<li>production</li>\n</ul>\n","title":"New Schemas Added"},{"date":"October 31, 2018","html_content":"<p>Presto views were not being indexed correctly in Amundsen. As of September 27th 2018, we have removed Presto views from Amundsen until we scope out a long term solution. See <a href=\"https://superset.lyft.net/superset/sqllab?id=1638\">this Superset query</a> for the full list of views that were removed.</p>","title":"Presto Views Removed"},{"date":"September 11, 2018","html_content":"<p>The search feature has been modified to work with query terms that include a period, underscore, or empty space. For example, you can now search for <code>core.fact_rides</code> or <code>core fact rides</code> or <code>fact_rides</code>. We now also display paginated results to further aid your search.</p>\n\n<p>Curious to know more about the frequent users of a resource? You can now click on a frequent user to get directed to their Family profile.<p>\n\n<p>Curious to know how a table was generated? We now provide a link to the Airflow DAG.<p>\n\n<p>We have updated the formatting of the url for the table detail page. Please make a note to update any links you may have shared with others or posted in any docs.</p>","title":"Search Improvements & New Features"}]})
+
+    return make_response(payload, HTTPStatus.OK)
+
     try:
         if ANNOUNCEMENT_CLIENT_INSTANCE is None and ANNOUNCEMENT_CLIENT_CLASS is not None:
             ANNOUNCEMENT_CLIENT_INSTANCE = ANNOUNCEMENT_CLIENT_CLASS()

--- a/amundsen_application/api/announcements/v0.py
+++ b/amundsen_application/api/announcements/v0.py
@@ -27,12 +27,6 @@ announcements_blueprint = Blueprint('announcements', __name__, url_prefix='/api/
 @announcements_blueprint.route('/', methods=['GET'])
 def get_announcements() -> Response:
     global ANNOUNCEMENT_CLIENT_INSTANCE
-
-    # Testing Code, remove at the end
-    payload = jsonify({"msg":"Success","posts":[{"date":"October 31, 2018","html_content":"Tables under the following schemas are now available in Amundsen! \ud83c\udf89\n\n<ul>\n<li>basemap</li>\n<li>driver_engagement</li>\n<li>enterprise</li>\n<li>experimentation</li>\n<li>production</li>\n</ul>\n","title":"New Schemas Added"},{"date":"October 31, 2018","html_content":"<p>Presto views were not being indexed correctly in Amundsen. As of September 27th 2018, we have removed Presto views from Amundsen until we scope out a long term solution. See <a href=\"https://superset.lyft.net/superset/sqllab?id=1638\">this Superset query</a> for the full list of views that were removed.</p>","title":"Presto Views Removed"},{"date":"September 11, 2018","html_content":"<p>The search feature has been modified to work with query terms that include a period, underscore, or empty space. For example, you can now search for <code>core.fact_rides</code> or <code>core fact rides</code> or <code>fact_rides</code>. We now also display paginated results to further aid your search.</p>\n\n<p>Curious to know more about the frequent users of a resource? You can now click on a frequent user to get directed to their Family profile.<p>\n\n<p>Curious to know how a table was generated? We now provide a link to the Airflow DAG.<p>\n\n<p>We have updated the formatting of the url for the table detail page. Please make a note to update any links you may have shared with others or posted in any docs.</p>","title":"Search Improvements & New Features"}]})
-
-    return make_response(payload, HTTPStatus.OK)
-
     try:
         if ANNOUNCEMENT_CLIENT_INSTANCE is None and ANNOUNCEMENT_CLIENT_CLASS is not None:
             ANNOUNCEMENT_CLIENT_INSTANCE = ANNOUNCEMENT_CLIENT_CLASS()

--- a/amundsen_application/static/css/_layouts.scss
+++ b/amundsen_application/static/css/_layouts.scss
@@ -5,6 +5,8 @@
 
 $resource-header-height: 84px;
 $aside-separation-space: 40px;
+$screen-lg-max: 1490px;
+$screen-lg-container: 1440px;
 
 .resource-detail-layout {
   height: calc(100vh - #{$nav-bar-height} - #{$footer-height});
@@ -196,6 +198,12 @@ $aside-separation-space: 40px;
 // Main Layout
 #main {
   min-width: $body-min-width;
+}
+
+@media (min-width: $screen-lg-max) {
+  #main > .container {
+    width: $screen-lg-container;
+  }
 }
 
 #main > .container {

--- a/amundsen_application/static/css/_variables-default.scss
+++ b/amundsen_application/static/css/_variables-default.scss
@@ -27,7 +27,6 @@ $stroke-underline: $gray40 !default;
 // Typography
 $text-primary: $gray100 !default;
 $text-secondary: $gray60 !default;
-$text-secondary: $gray60 !default;
 $text-tertiary: $gray40 !default;
 $text-placeholder: $gray40 !default;
 $text-inverse: $white !default;

--- a/amundsen_application/static/js/components/HomePage/index.tsx
+++ b/amundsen_application/static/js/components/HomePage/index.tsx
@@ -9,14 +9,15 @@ import { RouteComponentProps } from 'react-router';
 // TODO: Use css-modules instead of 'import'
 import './styles.scss';
 
+import { resetSearchState } from 'ducks/search/reducer';
+import { UpdateSearchStateReset } from 'ducks/search/types';
+
 import MyBookmarks from 'components/common/Bookmark/MyBookmarks';
 import Breadcrumb from 'components/common/Breadcrumb';
 import PopularTables from 'components/common/PopularTables';
-import { resetSearchState } from 'ducks/search/reducer';
-import { UpdateSearchStateReset } from 'ducks/search/types';
 import SearchBar from 'components/common/SearchBar';
 import TagsList from 'components/common/TagsList';
-import Card from 'components/common/Card';
+import Announcements from 'components/common/Announcements';
 import {
   SEARCH_BREADCRUMB_TEXT,
   HOMEPAGE_TITLE,
@@ -38,7 +39,7 @@ export class HomePage extends React.Component<HomePageProps> {
     return (
       <main className="container home-page">
         <div className="row">
-          <div className="col-xs-12 col-md-offset-1 col-md-10">
+          <div className="col-xs-12 col-md-9">
             <h1 className="sr-only">{HOMEPAGE_TITLE}</h1>
             <SearchBar />
             <div className="filter-breadcrumb pull-right">
@@ -63,6 +64,9 @@ export class HomePage extends React.Component<HomePageProps> {
             <div className="home-element-container">
               <PopularTables />
             </div>
+          </div>
+          <div className="col-xs-12 col-md-3">
+            <Announcements />
           </div>
         </div>
       </main>

--- a/amundsen_application/static/js/components/HomePage/index.tsx
+++ b/amundsen_application/static/js/components/HomePage/index.tsx
@@ -39,7 +39,7 @@ export class HomePage extends React.Component<HomePageProps> {
     return (
       <main className="container home-page">
         <div className="row">
-          <div className="col-xs-12 col-md-9">
+          <div className="col-xs-12 col-md-8">
             <h1 className="sr-only">{HOMEPAGE_TITLE}</h1>
             <SearchBar />
             <div className="filter-breadcrumb pull-right">
@@ -65,7 +65,7 @@ export class HomePage extends React.Component<HomePageProps> {
               <PopularTables />
             </div>
           </div>
-          <div className="col-xs-12 col-md-3">
+          <div className="col-xs-12 col-md-offset-1 col-md-3">
             <Announcements />
           </div>
         </div>

--- a/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.spec.tsx
@@ -3,6 +3,8 @@ import { Link, BrowserRouter } from 'react-router-dom';
 import SanitizedHTML from 'react-sanitized-html';
 import { mount } from 'enzyme';
 
+import Card from '../../Card';
+
 import AnnouncementsList, { AnnouncementsListProps } from '.';
 
 const TWO_FAKE_ANNOUNCEMENTS = [
@@ -73,7 +75,7 @@ describe('AnnouncementsList', () => {
 
     describe('See more link', () => {
       it('should render a "See more" link', () => {
-        const { wrapper } = setup();
+        const { wrapper } = setup({ announcements: TWO_FAKE_ANNOUNCEMENTS });
         const expected = 1;
         const actual = wrapper.find('a.announcements-list-more-link').length;
 
@@ -81,7 +83,7 @@ describe('AnnouncementsList', () => {
       });
 
       it('renders a react router Link', () => {
-        const { wrapper } = setup();
+        const { wrapper } = setup({ announcements: TWO_FAKE_ANNOUNCEMENTS });
         const expected = 1;
         const actual = wrapper.find(Link).length;
 
@@ -89,7 +91,7 @@ describe('AnnouncementsList', () => {
       });
 
       it('takes users to the announcements page', () => {
-        const { wrapper } = setup();
+        const { wrapper } = setup({ announcements: TWO_FAKE_ANNOUNCEMENTS });
         const expected = '/announcements';
         const actual = wrapper
           .find('a.announcements-list-more-link')
@@ -110,24 +112,35 @@ describe('AnnouncementsList', () => {
       });
 
       describe('when loading', () => {
-        it('should render the loading shimmer', () => {
-          const { wrapper } = setup({
-            announcements: EMPTY_ANNOUNCEMENTS,
-            isLoading: true,
-          });
-          const expected = 1;
-          const actual = wrapper.find('.shimmer-loader').length;
-
-          expect(actual).toEqual(expected);
-        });
-
-        it('should render three loading items', () => {
+        it('should render three cards', () => {
           const { wrapper } = setup({
             announcements: EMPTY_ANNOUNCEMENTS,
             isLoading: true,
           });
           const expected = 3;
-          const actual = wrapper.find('.shimmer-loader-item').length;
+          const actual = wrapper.find(Card).length;
+
+          expect(actual).toEqual(expected);
+        });
+
+        it('should render three cards in loading state', () => {
+          const { wrapper } = setup({
+            announcements: EMPTY_ANNOUNCEMENTS,
+            isLoading: true,
+          });
+          const expected = 3;
+          const actual = wrapper.find('.card-shimmer-loader').length;
+
+          expect(actual).toEqual(expected);
+        });
+
+        it('should not render the see more link', () => {
+          const { wrapper } = setup({
+            announcements: EMPTY_ANNOUNCEMENTS,
+            isLoading: true,
+          });
+          const expected = 0;
+          const actual = wrapper.find('a.announcements-list-more-link').length;
 
           expect(actual).toEqual(expected);
         });
@@ -142,72 +155,12 @@ describe('AnnouncementsList', () => {
           expect(actual).toEqual(expected);
         });
 
-        it('should render announcement dates', () => {
+        it('should render announcement cards', () => {
           const { wrapper } = setup({ announcements: TWO_FAKE_ANNOUNCEMENTS });
           const expected = 2;
-          const actual = wrapper.find('.announcement-date').length;
+          const actual = wrapper.find(Card).length;
 
           expect(actual).toEqual(expected);
-        });
-
-        it('should render announcement titles', () => {
-          const { wrapper } = setup({ announcements: TWO_FAKE_ANNOUNCEMENTS });
-          const expected = 2;
-          const actual = wrapper.find('.announcement-title').length;
-
-          expect(actual).toEqual(expected);
-        });
-
-        it('should render announcement contents', () => {
-          const { wrapper } = setup({ announcements: TWO_FAKE_ANNOUNCEMENTS });
-          const expected = 2;
-          const actual = wrapper.find('div.announcement-content').length;
-
-          expect(actual).toEqual(expected);
-        });
-
-        it('should render sanitized announcement contents', () => {
-          const { wrapper } = setup({ announcements: TWO_FAKE_ANNOUNCEMENTS });
-          const expected = 2;
-          const actual = wrapper.find(SanitizedHTML).length;
-
-          expect(actual).toEqual(expected);
-        });
-
-        describe('announcement links', () => {
-          it('renders links from the announcements to the announcements page', () => {
-            const { wrapper } = setup({
-              announcements: TWO_FAKE_ANNOUNCEMENTS,
-            });
-            const expected = 2;
-            const actual = wrapper.find('a.announcement-link').length;
-
-            expect(actual).toEqual(expected);
-          });
-
-          it('renders react router Links', () => {
-            const { wrapper } = setup({
-              announcements: TWO_FAKE_ANNOUNCEMENTS,
-            });
-            const expected = 2;
-            const actual = wrapper.find('.announcement').find(Link).length;
-
-            expect(actual).toEqual(expected);
-          });
-
-          it('takes users to the announcements page', () => {
-            const { wrapper } = setup({
-              announcements: TWO_FAKE_ANNOUNCEMENTS,
-            });
-            const expected = '/announcements';
-            const actual = wrapper
-              .find('a.announcement-link')
-              .first()
-              .getDOMNode()
-              .attributes.getNamedItem('href').value;
-
-            expect(actual).toEqual(expected);
-          });
         });
 
         describe('when number of announcements is more than three', () => {
@@ -216,7 +169,7 @@ describe('AnnouncementsList', () => {
               announcements: FOUR_FAKE_ANNOUNCEMENTS,
             });
             const expected = 3;
-            const actual = wrapper.find('.announcement').length;
+            const actual = wrapper.find(Card).length;
 
             expect(actual).toEqual(expected);
           });
@@ -231,6 +184,14 @@ describe('AnnouncementsList', () => {
 
           expect(actual).toEqual(expected);
         });
+
+        it('should not render the see more link', () => {
+          const { wrapper } = setup({ announcements: EMPTY_ANNOUNCEMENTS });
+          const expected = 0;
+          const actual = wrapper.find('a.announcements-list-more-link').length;
+
+          expect(actual).toEqual(expected);
+        });
       });
 
       describe('when error on fetch', () => {
@@ -240,7 +201,18 @@ describe('AnnouncementsList', () => {
             hasError: true,
           });
           const expected = 1;
-          const actual = wrapper.find('.announcement-error').length;
+          const actual = wrapper.find('.error-announcement').length;
+
+          expect(actual).toEqual(expected);
+        });
+
+        it('should not render the see more link', () => {
+          const { wrapper } = setup({
+            announcements: EMPTY_ANNOUNCEMENTS,
+            hasError: true,
+          });
+          const expected = 0;
+          const actual = wrapper.find('a.announcements-list-more-link').length;
 
           expect(actual).toEqual(expected);
         });

--- a/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.spec.tsx
@@ -84,7 +84,7 @@ describe('AnnouncementsList', () => {
 
       it('renders a react router Link', () => {
         const { wrapper } = setup({ announcements: TWO_FAKE_ANNOUNCEMENTS });
-        const expected = 1;
+        const expected = TWO_FAKE_ANNOUNCEMENTS.length + 1;
         const actual = wrapper.find(Link).length;
 
         expect(actual).toEqual(expected);

--- a/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.tsx
+++ b/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import SanitizedHTML from 'react-sanitized-html';
 
+import { logClick } from 'ducks/utilMethods';
+
 import { AnnouncementPost } from 'interfaces';
 import Card from '../../Card';
 
@@ -41,6 +43,7 @@ const AnnouncementItem: React.FC<AnnouncementPost> = ({
         title={title}
         subtitle={date}
         href={ANNOUNCEMENTS_PAGE_PATH}
+        onClick={logClick}
         copy={
           <SanitizedHTML className="announcement-content" html={html_content} />
         }
@@ -98,6 +101,7 @@ const AnnouncementsList: React.FC<AnnouncementsListProps> = ({
         <Link
           to={ANNOUNCEMENTS_PAGE_PATH}
           className="announcements-list-more-link"
+          onClick={logClick}
         >
           {MORE_LINK_TEXT}
         </Link>

--- a/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.tsx
+++ b/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.tsx
@@ -40,6 +40,7 @@ const AnnouncementItem: React.FC<AnnouncementPost> = ({
       <Card
         title={title}
         subtitle={date}
+        href={ANNOUNCEMENTS_PAGE_PATH}
         copy={
           <SanitizedHTML className="announcement-content" html={html_content} />
         }
@@ -47,7 +48,6 @@ const AnnouncementItem: React.FC<AnnouncementPost> = ({
     </li>
   );
 };
-// href={ANNOUNCEMENTS_PAGE_PATH}
 
 const EmptyAnnouncementItem: React.FC = () => (
   <li className="empty-announcement">{NO_ANNOUNCEMENTS_TEXT}</li>

--- a/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.tsx
+++ b/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.tsx
@@ -84,16 +84,16 @@ const AnnouncementsList: React.FC<AnnouncementsListProps> = ({
   }
   if (isLoading) {
     listContent = times(3).map((_, index) => (
-      <Card title="Loading" key={`key:${index}`} isLoading />
+      <li className="announcement" key={`key:${index}`}>
+        <Card isLoading />
+      </li>
     ));
   }
 
   return (
     <article className="announcements-list-container">
       <h2 className="announcements-list-title">{HEADER_TEXT}</h2>
-      <ul className={`announcements-list ${isLoading ? 'shimmer-loader' : ''}`}>
-        {listContent}
-      </ul>
+      <ul className="announcements-list">{listContent}</ul>
       {!isEmpty && (
         <Link
           to={ANNOUNCEMENTS_PAGE_PATH}

--- a/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.tsx
+++ b/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import SanitizedHTML from 'react-sanitized-html';
 
 import { AnnouncementPost } from 'interfaces';
+import Card from '../../Card';
 
 import {
   MORE_LINK_TEXT,
@@ -10,6 +11,8 @@ import {
   ANNOUNCEMENTS_ERROR_TEXT,
   HEADER_TEXT,
 } from '../constants';
+
+import './styles.scss';
 
 const ANNOUNCEMENT_LIST_THRESHOLD = 3;
 const ANNOUNCEMENTS_PAGE_PATH = '/announcements';
@@ -34,24 +37,23 @@ const AnnouncementItem: React.FC<AnnouncementPost> = ({
 }: AnnouncementPost) => {
   return (
     <li className="announcement">
-      <Link to={ANNOUNCEMENTS_PAGE_PATH} className="announcement-link">
-        <h3 className="announcement-title">{title}</h3>
-        <time className="announcement-date">{date}</time>
-        <hr />
-        <SanitizedHTML className="announcement-content" html={html_content} />
-      </Link>
+      <Card
+        title={title}
+        subtitle={date}
+        copy={
+          <SanitizedHTML className="announcement-content" html={html_content} />
+        }
+      />
     </li>
   );
 };
+// href={ANNOUNCEMENTS_PAGE_PATH}
 
 const EmptyAnnouncementItem: React.FC = () => (
   <li className="empty-announcement">{NO_ANNOUNCEMENTS_TEXT}</li>
 );
 const AnnouncementErrorItem: React.FC = () => (
-  <li className="announcement-error">{ANNOUNCEMENTS_ERROR_TEXT}</li>
-);
-const ShimmeringLoaderItem: React.FC = () => (
-  <li className="shimmer-loader-item is-shimmer-animated" />
+  <li className="error-announcement">{ANNOUNCEMENTS_ERROR_TEXT}</li>
 );
 
 const AnnouncementsList: React.FC<AnnouncementsListProps> = ({
@@ -59,9 +61,10 @@ const AnnouncementsList: React.FC<AnnouncementsListProps> = ({
   hasError,
   isLoading,
 }: AnnouncementsListProps) => {
+  const isEmpty = announcements.length === 0;
   let listContent = null;
 
-  if (announcements.length === 0) {
+  if (isEmpty) {
     listContent = <EmptyAnnouncementItem />;
   }
   if (announcements.length > 0) {
@@ -81,22 +84,24 @@ const AnnouncementsList: React.FC<AnnouncementsListProps> = ({
   }
   if (isLoading) {
     listContent = times(3).map((_, index) => (
-      <ShimmeringLoaderItem key={`key:${index}`} />
+      <Card title="Loading" key={`key:${index}`} isLoading />
     ));
   }
 
   return (
-    <article>
+    <article className="announcements-list-container">
       <h2 className="announcements-list-title">{HEADER_TEXT}</h2>
       <ul className={`announcements-list ${isLoading ? 'shimmer-loader' : ''}`}>
         {listContent}
       </ul>
-      <Link
-        to={ANNOUNCEMENTS_PAGE_PATH}
-        className="announcements-list-more-link"
-      >
-        {MORE_LINK_TEXT}
-      </Link>
+      {!isEmpty && (
+        <Link
+          to={ANNOUNCEMENTS_PAGE_PATH}
+          className="announcements-list-more-link"
+        >
+          {MORE_LINK_TEXT}
+        </Link>
+      )}
     </article>
   );
 };

--- a/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/styles.scss
+++ b/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/styles.scss
@@ -1,0 +1,29 @@
+@import 'variables';
+
+.announcements-list-container {
+}
+
+.announcements-list-title {
+}
+
+.announcements-list {
+  list-style: none;
+  margin: $spacer-1 0 0 0;
+  padding: 0;
+}
+
+.announcements-list-more-link {
+  font-size: 18px;
+  line-height: 21px;
+  margin-top: $spacer-1;
+}
+
+.empty-announcement,
+.error-announcement {
+  font-size: 14px;
+  line-height: 16px;
+  color: $gray100;
+  text-align: center;
+  border-top: 1px solid $gray20;
+  padding-top: $spacer-3;
+}

--- a/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/styles.scss
+++ b/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/styles.scss
@@ -1,9 +1,7 @@
 @import 'variables';
 
 .announcements-list-container {
-}
-
-.announcements-list-title {
+  margin-top: $spacer-3;
 }
 
 .announcements-list {

--- a/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/styles.scss
+++ b/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/styles.scss
@@ -1,5 +1,11 @@
 @import 'variables';
 
+$more-link-size: 18px;
+$more-link-line-height: 21px;
+$message-size: 14px;
+$message-line-height: 16px;
+$message-border-size: 1px;
+
 .announcements-list-container {
   margin-top: $spacer-3;
 }
@@ -19,18 +25,18 @@
 }
 
 .announcements-list-more-link {
-  font-size: 18px;
-  line-height: 21px;
+  font-size: $more-link-size;
+  line-height: $more-link-line-height;
   margin-top: 12px;
   display: block;
 }
 
 .empty-announcement,
 .error-announcement {
-  font-size: 14px;
-  line-height: 16px;
-  color: $gray100;
+  font-size: $message-size;
+  line-height: $message-line-height;
+  color: $text-primary;
   text-align: center;
-  border-top: 1px solid $gray20;
+  border-top: $message-border-size solid $gray20;
   padding-top: $spacer-3;
 }

--- a/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/styles.scss
+++ b/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/styles.scss
@@ -10,12 +10,21 @@
   list-style: none;
   margin: $spacer-1 0 0 0;
   padding: 0;
+
+  .announcement {
+    margin-bottom: -1px;
+  }
+
+  .announcement-content p {
+    margin: 0;
+  }
 }
 
 .announcements-list-more-link {
   font-size: 18px;
   line-height: 21px;
-  margin-top: $spacer-1;
+  margin-top: 12px;
+  display: block;
 }
 
 .empty-announcement,

--- a/amundsen_application/static/js/components/common/Announcements/index.tsx
+++ b/amundsen_application/static/js/components/common/Announcements/index.tsx
@@ -32,7 +32,7 @@ const AnnouncementsListContainer: React.FC<AnnouncementContainerProps> = ({
 }: AnnouncementContainerProps) => {
   React.useEffect(() => {
     announcementsGet();
-  });
+  }, []);
 
   return (
     <AnnouncementsList

--- a/amundsen_application/static/js/components/common/Card/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/Card/index.spec.tsx
@@ -165,4 +165,23 @@ describe('Card', () => {
       });
     });
   });
+
+  describe('lifetime', () => {
+    describe('when clicking on an interactive card', () => {
+      it('should call the onClick handler', () => {
+        const clickSpy = jest.fn();
+        const { wrapper } = setup({
+          onClick: clickSpy,
+          href: 'testPath',
+        });
+        const expected = 1;
+
+        wrapper.find(Link).simulate('click');
+
+        const actual = clickSpy.mock.calls.length;
+
+        expect(actual).toEqual(expected);
+      });
+    });
+  });
 });

--- a/amundsen_application/static/js/components/common/Card/index.tsx
+++ b/amundsen_application/static/js/components/common/Card/index.tsx
@@ -6,7 +6,7 @@ import './styles.scss';
 export interface CardProps {
   title?: string;
   subtitle?: string;
-  copy?: string;
+  copy?: string | JSX.Element;
   isLoading?: boolean;
   href?: string;
 }
@@ -39,7 +39,7 @@ const Card: React.FC<CardProps> = ({
         {subtitle && <h3 className="card-subtitle">{subtitle}</h3>}
       </header>
       <div className="card-body">
-        {copy && <p className="card-copy">{copy}</p>}
+        {copy && <div className="card-copy">{copy}</div>}
       </div>
     </>
   );

--- a/amundsen_application/static/js/components/common/Card/index.tsx
+++ b/amundsen_application/static/js/components/common/Card/index.tsx
@@ -9,6 +9,7 @@ export interface CardProps {
   copy?: string | JSX.Element;
   isLoading?: boolean;
   href?: string;
+  onClick?: (e: React.SyntheticEvent) => void;
 }
 
 const CardShimmerLoader: React.FC = () => (
@@ -29,6 +30,7 @@ const Card: React.FC<CardProps> = ({
   title,
   subtitle,
   copy,
+  onClick = null,
   isLoading = false,
 }: CardProps) => {
   let card;
@@ -53,6 +55,7 @@ const Card: React.FC<CardProps> = ({
       <Link
         className={`card is-link ${isLoading ? 'is-loading' : ''}`}
         to={href}
+        onClick={onClick}
       >
         {cardContent}
       </Link>

--- a/amundsen_application/static/js/components/common/Card/styles.scss
+++ b/amundsen_application/static/js/components/common/Card/styles.scss
@@ -39,6 +39,7 @@ $card-copy-max-lines: 3;
     &:active {
       text-decoration: none;
       box-shadow: $elevation-level2;
+      border: 0;
     }
   }
 }
@@ -52,7 +53,7 @@ $card-copy-max-lines: 3;
   font-size: $card-title-font-size;
   line-height: $card-title-line-height;
   font-weight: $font-weight-body-bold;
-  color: $gray100;
+  color: $text-primary;
 
   @include truncate(
     $card-title-font-size,
@@ -66,7 +67,7 @@ $card-copy-max-lines: 3;
   font-size: $card-subtitle-font-size;
   line-height: $card-subtitle-line-height;
   font-weight: $font-weight-body-regular;
-  color: $gray70;
+  color: $text-secondary;
 }
 
 .card-copy {
@@ -74,7 +75,7 @@ $card-copy-max-lines: 3;
   font-size: $card-copy-font-size;
   line-height: $card-copy-line-height;
   font-weight: $font-weight-body-regular;
-  color: $gray100;
+  color: $text-primary;
   margin: 0;
 
   @include truncate(


### PR DESCRIPTION
### Summary of Changes
Adds the announcements block into the homepage
Wires the cards to the announcements list
Updates maximum container to match designs

![Amundsen_-_Data_Discovery_Portal](https://user-images.githubusercontent.com/190833/89839173-fd66d500-db21-11ea-801e-ea3a2613e57c.png)


### Tests
Updated tests

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
