### PR TITLE
build: remove defunct eslint tsconfig file

### DIFF
--- a/amundsen_application/static/tsconfig.eslint.json
+++ b/amundsen_application/static/tsconfig.eslint.json
@@ -1,8 +1,0 @@
-{
-  "compilerOptions": { "strict": true },
-  "include": [
-    "*.js",
-    "*.ts",
-    "js/**/*.tsx"
-  ]
-}


### PR DESCRIPTION
### Summary of Changes

Can't find anywhere this is referenced, in package.json we specify:
```
    "parser": "@typescript-eslint/parser",
    "parserOptions": {
      "project": "tsconfig.json",
      "sourceType": "module"
    },
```

so i'm pretty sure this is defunct. Tests will tell :) 

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
