### PR TITLE
fix: Fixes ordering issue on announcements on homepage

### DIFF
--- a/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.spec.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Link, BrowserRouter } from 'react-router-dom';
-import SanitizedHTML from 'react-sanitized-html';
 import { mount } from 'enzyme';
 
 import Card from '../../Card';
@@ -9,26 +8,21 @@ import AnnouncementsList, { AnnouncementsListProps } from '.';
 
 const TWO_FAKE_ANNOUNCEMENTS = [
   {
-    date: '12/31/1999',
-    title: 'Y2K',
-    html_content: '<div>The end of the world</div>',
-  },
-  {
     date: '01/01/2000',
     title: 'False Alarm',
     html_content: '<div>Just kidding</div>',
+  },
+  {
+    date: '12/31/1999',
+    title: 'Y2K',
+    html_content: '<div>The end of the world</div>',
   },
 ];
 const FOUR_FAKE_ANNOUNCEMENTS = [
   {
-    date: '12/31/1999',
-    title: 'Y2K',
-    html_content: '<div>The end of the world</div>',
-  },
-  {
-    date: '01/01/2000',
-    title: 'False Alarm',
-    html_content: '<div>Just kidding</div>',
+    date: '01/01/2020',
+    title: 'New Test',
+    html_content: '<div>New test</div>',
   },
   {
     date: '12/31/2009',
@@ -36,9 +30,14 @@ const FOUR_FAKE_ANNOUNCEMENTS = [
     html_content: '<div>Old test</div>',
   },
   {
-    date: '01/01/2020',
-    title: 'New Test',
-    html_content: '<div>New test</div>',
+    date: '01/01/2000',
+    title: 'False Alarm',
+    html_content: '<div>Just kidding</div>',
+  },
+  {
+    date: '12/31/1999',
+    title: 'Y2K',
+    html_content: '<div>The end of the world</div>',
   },
 ];
 const EMPTY_ANNOUNCEMENTS = [];
@@ -170,6 +169,27 @@ describe('AnnouncementsList', () => {
             });
             const expected = 3;
             const actual = wrapper.find(Card).length;
+
+            expect(actual).toEqual(expected);
+            wrapper.unmount();
+          });
+
+          it('should render them starting on the latest announcement', () => {
+            const { wrapper } = setup({
+              announcements: FOUR_FAKE_ANNOUNCEMENTS,
+            });
+            const firstCardDate = wrapper
+              .find(Card)
+              .at(0)
+              .find('.card-subtitle')
+              .text();
+            const lastCardDate = wrapper
+              .find(Card)
+              .at(1)
+              .find('.card-subtitle')
+              .text();
+            const actual = new Date(firstCardDate) >= new Date(lastCardDate);
+            const expected = true;
 
             expect(actual).toEqual(expected);
           });

--- a/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.tsx
+++ b/amundsen_application/static/js/components/common/Announcements/AnnouncementsList/index.tsx
@@ -27,7 +27,7 @@ export interface AnnouncementsListProps {
 
 const getLatestsAnnouncements = (announcements: AnnouncementPost[]) =>
   announcements.length > ANNOUNCEMENT_LIST_THRESHOLD
-    ? announcements.splice(announcements.length - ANNOUNCEMENT_LIST_THRESHOLD)
+    ? announcements.slice(0, ANNOUNCEMENT_LIST_THRESHOLD)
     : announcements;
 
 const times = (numItems: number) => new Array(numItems).fill(0);


### PR DESCRIPTION
### Summary of Changes
Fixes issue where announcements on homepage show up starting with the latest one

### Tests
Added a regression test

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
