### PR TITLE
fix: Remove css contenthash due to no effect if using random values

### DIFF
--- a/amundsen_application/static/webpack.prod.ts
+++ b/amundsen_application/static/webpack.prod.ts
@@ -17,7 +17,7 @@ export default merge(commonConfig, {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: '[name].[contenthash].css',
+      filename: '[name].css',
     }),
   ],
 });


### PR DESCRIPTION
Signed-off-by: Tamika Tannis <ttannis@lyft.com>

### Summary of Changes

We have observed that the `contenthash` for the css files are different each time the same commit is built, due to the use of `random` in some of our shimmer styles. 

As a result the content is different each time, which negates the benefits of using hashes. If merged, we still have the option of revisiting this to reconsider the use of `random` in our styles in order to reintroduce content hashing on the css files. 

### Tests

N/A

### Documentation

N/A

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
