### PR TITLE
fix: Remove randomized css widths

### DIFF
--- a/amundsen_application/static/js/components/common/Card/styles.scss
+++ b/amundsen_application/static/js/components/common/Card/styles.scss
@@ -4,7 +4,7 @@
 $shimmer-loader-items: 1, 2, 3, 4, 5;
 $shimmer-loader-row-height: 16px;
 $shimmer-loader-row-min-width: 90;
-$shimmer-loader-row-max-width: 230;
+$shimmer-loader-row-width: 160;
 
 $card-height: 180px;
 $card-header-height: 60px;
@@ -86,11 +86,7 @@ $card-copy-max-lines: 3;
 
 @each $line in $shimmer-loader-items {
   .shimmer-row-line--#{$line} {
-    width: (
-        random($shimmer-loader-row-max-width - $shimmer-loader-row-min-width) +
-          $shimmer-loader-row-min-width
-      ) +
-      px;
+    width: $shimmer-loader-row-width + px;
   }
 }
 

--- a/amundsen_application/static/js/components/common/ShimmeringResourceLoader/styles.scss
+++ b/amundsen_application/static/js/components/common/ShimmeringResourceLoader/styles.scss
@@ -37,6 +37,6 @@ $shimmer-loader-border-size: 1px;
 
 @each $line in $shimmer-loader-lines {
   .shimmer-resource-line--#{$line} {
-    width: percentage(random(100) / 100);
+    width: 75%;
   }
 }

--- a/amundsen_application/static/js/components/common/ShimmeringTagListLoader/styles.scss
+++ b/amundsen_application/static/js/components/common/ShimmeringTagListLoader/styles.scss
@@ -6,18 +6,11 @@
 $shimmer-loader-tag-height: 36px;
 $shimmer-loader-items: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14;
 $shimmer-loader-tag-width: 90;
-$shimmer-loader-tag-min-width: 50;
 
 .shimmer-tag-loader-item {
   margin: 0 $spacer-1 $spacer-1 0;
   height: $shimmer-loader-tag-height;
-  width: $shimmer-loader-tag-min-width + px;
+  width: $shimmer-loader-tag-width + px;
   border-radius: $tag-border-radius;
   display: inline-block;
-}
-
-@each $item in $shimmer-loader-items {
-  .shimmer-tag-loader-item--#{$item} {
-    width: $shimmer-loader-tag-width + px;
-  }
 }

--- a/amundsen_application/static/js/components/common/ShimmeringTagListLoader/styles.scss
+++ b/amundsen_application/static/js/components/common/ShimmeringTagListLoader/styles.scss
@@ -5,7 +5,7 @@
 
 $shimmer-loader-tag-height: 36px;
 $shimmer-loader-items: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14;
-$shimmer-loader-tag-max-width: 130;
+$shimmer-loader-tag-width: 90;
 $shimmer-loader-tag-min-width: 50;
 
 .shimmer-tag-loader-item {
@@ -18,10 +18,6 @@ $shimmer-loader-tag-min-width: 50;
 
 @each $item in $shimmer-loader-items {
   .shimmer-tag-loader-item--#{$item} {
-    width: (
-        random($shimmer-loader-tag-max-width - $shimmer-loader-tag-min-width) +
-          $shimmer-loader-tag-min-width
-      ) +
-      px;
+    width: $shimmer-loader-tag-width + px;
   }
 }

--- a/amundsen_application/static/js/pages/DashboardPage/QueryListItem/styles.scss
+++ b/amundsen_application/static/js/pages/DashboardPage/QueryListItem/styles.scss
@@ -135,7 +135,7 @@ $shimmer-loader-lines: 1, 2, 3, 4, 5, 6;
 
   @each $line in $shimmer-loader-lines {
     .shimmer-line--#{$line} {
-      width: percentage(random(100) / 100);
+      width: 75%;
     }
   }
 }

--- a/amundsen_application/static/js/pages/TableDetailPage/TableIssues/styles.scss
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableIssues/styles.scss
@@ -90,7 +90,7 @@ $shimmer-loader-lines: 1, 2;
 
   @each $line in $shimmer-loader-lines {
     .shimmer-issues-line--#{$line} {
-      width: percentage(random(100) / 100);
+      width: 75%;
     }
   }
 }

--- a/amundsen_application/static/webpack.prod.ts
+++ b/amundsen_application/static/webpack.prod.ts
@@ -17,7 +17,7 @@ export default merge(commonConfig, {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: '[name].[contenthash].css',
+      filename: '[name].css',
     }),
   ],
 });

--- a/amundsen_application/static/webpack.prod.ts
+++ b/amundsen_application/static/webpack.prod.ts
@@ -17,7 +17,7 @@ export default merge(commonConfig, {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: '[name].css',
+      filename: '[name].[contenthash].css',
     }),
   ],
 });


### PR DESCRIPTION
### Summary of Changes

Using randomized widths negates the effects of css content hashing, as the built content will be different each time due to the random widths. This PR removes those usages, and for now I have just chosen `75%` for widths that need a percentage, and splitting the different between the old max width and min width for others.

### Tests

N/A but confirmed the build returns the same `contenthash` each time. 

### Documentation

N/A

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
