### PR TITLE
chore: Bumped flaskoidc dependency

### DIFF
--- a/public.Dockerfile
+++ b/public.Dockerfile
@@ -28,11 +28,11 @@ ENV FRONTEND_SVC_CONFIG_MODULE_CLASS amundsen_application.oidc_config.OidcConfig
 ENV APP_WRAPPER flaskoidc
 ENV APP_WRAPPER_CLASS FlaskOIDC
 ENV FLASK_OIDC_WHITELISTED_ENDPOINTS status,healthcheck,health
-ENV FLASK_OIDC_SQLALCHEMY_DATABASE_URI sqlite:///sessions.db
+ENV SQLALCHEMY_DATABASE_URI sqlite:///sessions.db
 
 # You will need to set these environment variables in order to use the oidc image
-# FLASK_OIDC_CLIENT_SECRETS - a path to a client_secrets.json file
-# FLASK_OIDC_SECRET_KEY - A secret key from your oidc provider
+# OIDC_CLIENT_SECRETS - a path to a client_secrets.json file
+# OIDC_SECRET_KEY - A secret key from your oidc provider
 # You will also need to mount a volume for the clients_secrets.json file.
 
 FROM base as release

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     dependency_links=[],
     install_requires=requirements,
     extras_require={
-        'oidc': ['flaskoidc==0.0.2']
+        'oidc': ['flaskoidc==0.1.0']
     },
     python_requires=">=3.6",
     entry_points="""


### PR DESCRIPTION
Bumping flaskoidc to version 0.1.0 will allow users to set the redirect url with an environment variable.

Thus, when merged the following two issues can be closed. https://github.com/amundsen-io/amundsenfrontendlibrary/pull/674 and https://github.com/amundsen-io/amundsen/issues/594

After merge I will update Amundsen main repo and I guess we can get to https://github.com/amundsen-io/amundsen/pull/354 too with a few updates to the helm charts reflecting the capabilities of flask v0.1.0.