### PR TITLE
fix: accept non int stats values

### DIFF
--- a/amundsen_application/static/js/components/ColumnList/ColumnStats/index.spec.tsx
+++ b/amundsen_application/static/js/components/ColumnList/ColumnStats/index.spec.tsx
@@ -114,5 +114,27 @@ describe('ColumnStats', () => {
         expect(actual).toEqual(expected);
       });
     });
+
+    describe('when different stat values are passed', () => {
+      const { stats } = dataBuilder.withNonNumericStats().build();
+
+      it('displays formatted number', () => {
+        const { wrapper } = setup({ stats });
+        const actual = wrapper.find('.stat-value').first().text();
+
+        const expected = '12,345';
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('displays date string', () => {
+        const { wrapper } = setup({ stats });
+        const actual = wrapper.find('.stat-value').last().text();
+
+        const expected = '2020-11-03';
+
+        expect(actual).toEqual(expected);
+      });
+    });
   });
 });

--- a/amundsen_application/static/js/components/ColumnList/ColumnStats/index.tsx
+++ b/amundsen_application/static/js/components/ColumnList/ColumnStats/index.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 
 import { TableColumnStats } from 'interfaces/index';
-import { formatNumber } from 'utils/numberUtils';
+import { formatNumber, isNumber } from 'utils/numberUtils';
 import { getStatsInfoText } from '../utils';
 
 import { COLUMN_STATS_TITLE } from '../constants';
@@ -27,7 +27,9 @@ const ColumnStatRow: React.FC<ColumnStatRowProps> = ({
   return (
     <div className="column-stat-row">
       <div className="stat-name body-3">{stat_type.toUpperCase()}</div>
-      <div className="stat-value">{Number(stat_val) ? formatNumber(+stat_val) : stat_val}</div>
+      <div className="stat-value">
+        {isNumber(stat_val) ? formatNumber(+stat_val) : stat_val}
+      </div>
     </div>
   );
 };

--- a/amundsen_application/static/js/components/ColumnList/ColumnStats/index.tsx
+++ b/amundsen_application/static/js/components/ColumnList/ColumnStats/index.tsx
@@ -24,12 +24,10 @@ const ColumnStatRow: React.FC<ColumnStatRowProps> = ({
   stat_type,
   stat_val,
 }: ColumnStatRowProps) => {
-  const numberVal = +stat_val;
-
   return (
     <div className="column-stat-row">
       <div className="stat-name body-3">{stat_type.toUpperCase()}</div>
-      <div className="stat-value">{formatNumber(numberVal)}</div>
+      <div className="stat-value">{Number(stat_val) ? formatNumber(+stat_val) : stat_val}</div>
     </div>
   );
 };

--- a/amundsen_application/static/js/components/ColumnList/ColumnStats/testDataBuilder.ts
+++ b/amundsen_application/static/js/components/ColumnList/ColumnStats/testDataBuilder.ts
@@ -135,6 +135,26 @@ function TestDataBuilder(config = {}) {
 
     return new this.Klass(attr);
   };
+  this.withNonNumericStats = () => {
+    const attr = {
+      stats: [
+        {
+          end_epoch: 1571616000,
+          start_epoch: 1571616000,
+          stat_type: 'count',
+          stat_val: '12345',
+        },
+        {
+          end_epoch: 1571616000,
+          start_epoch: 1571616000,
+          stat_type: 'date',
+          stat_val: '2020-11-03',
+        },
+      ],
+    };
+
+    return new this.Klass(attr);
+  };
 
   this.withEmptyStats = () => {
     const attr = { stats: [] };

--- a/amundsen_application/static/js/utils/index.spec.ts
+++ b/amundsen_application/static/js/utils/index.spec.ts
@@ -1,8 +1,12 @@
 import { ResourceType } from 'interfaces/Resources';
+import { assert } from 'console';
+import { access } from 'fs';
+import { sys } from 'typescript';
 import * as DateUtils from './dateUtils';
 import * as LogUtils from './logUtils';
 import * as NavigationUtils from './navigationUtils';
 import * as TextUtils from './textUtils';
+import * as NumberUtils from './numberUtils';
 
 describe('textUtils', () => {
   describe('convertText', () => {
@@ -42,6 +46,41 @@ describe('textUtils', () => {
         TextUtils.CaseType.TITLE_CASE
       );
       const expected = 'Test Title Case';
+
+      expect(actual).toEqual(expected);
+    });
+  });
+});
+
+describe('numberUtils', () => {
+  describe('isNumber', () => {
+    it('returns true if string is number', () => {
+      const actual = NumberUtils.isNumber('1234');
+      const expected = true;
+
+      expect(actual).toEqual(expected);
+    });
+    it('returns false if string is not number', () => {
+      const actual_string = NumberUtils.isNumber('abcd');
+      const actual_date = NumberUtils.isNumber('2020-11-03');
+      const actual_alpha_num = NumberUtils.isNumber('1a2b3c');
+      const expected = false;
+
+      expect(actual_string).toEqual(expected);
+      expect(actual_date).toEqual(expected);
+      expect(actual_alpha_num).toEqual(expected);
+    });
+  });
+  describe('formatNumber', () => {
+    it('returns formatted number', () => {
+      const actual = NumberUtils.formatNumber('1998');
+      const expected = '1,998';
+
+      expect(actual).toEqual(expected);
+    });
+    it('get NaN on non numbers', () => {
+      const actual = NumberUtils.formatNumber('2020-11-03');
+      const expected = 'NaN';
 
       expect(actual).toEqual(expected);
     });

--- a/amundsen_application/static/js/utils/index.spec.ts
+++ b/amundsen_application/static/js/utils/index.spec.ts
@@ -61,14 +61,14 @@ describe('numberUtils', () => {
       expect(actual).toEqual(expected);
     });
     it('returns false if string is not number', () => {
-      const actual_string = NumberUtils.isNumber('abcd');
-      const actual_date = NumberUtils.isNumber('2020-11-03');
-      const actual_alpha_num = NumberUtils.isNumber('1a2b3c');
+      const actualString = NumberUtils.isNumber('abcd');
+      const actualDate = NumberUtils.isNumber('2020-11-03');
+      const actualAlphaNum = NumberUtils.isNumber('1a2b3c');
       const expected = false;
 
-      expect(actual_string).toEqual(expected);
-      expect(actual_date).toEqual(expected);
-      expect(actual_alpha_num).toEqual(expected);
+      expect(actualString).toEqual(expected);
+      expect(actualDate).toEqual(expected);
+      expect(actualAlphaNum).toEqual(expected);
     });
   });
   describe('formatNumber', () => {

--- a/amundsen_application/static/js/utils/numberUtils.ts
+++ b/amundsen_application/static/js/utils/numberUtils.ts
@@ -12,3 +12,9 @@ export function formatNumber(value) {
   }
   return Intl.NumberFormat().format(value);
 }
+
+export function isNumber(value) {
+  if (typeof value == 'string') {
+    return !Number.isNaN(Number(value));
+  }
+}

--- a/amundsen_application/static/js/utils/numberUtils.ts
+++ b/amundsen_application/static/js/utils/numberUtils.ts
@@ -13,8 +13,6 @@ export function formatNumber(value) {
   return Intl.NumberFormat().format(value);
 }
 
-export function isNumber(value) {
-  if (typeof value == 'string') {
-    return !Number.isNaN(Number(value));
-  }
+export function isNumber(value): boolean {
+  return !Number.isNaN(Number(value));
 }


### PR DESCRIPTION
### Summary of Changes

Changed logic so non numerical stats values will not be converted to int.
https://github.com/amundsen-io/amundsen/issues/778

### Tests

test cases where stats values are dates.

### Documentation

N/A

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
