### PR TITLE
chore: Change deprecated pytest function

### DIFF
--- a/tests/unit/api/mail/test_v0.py
+++ b/tests/unit/api/mail/test_v0.py
@@ -133,7 +133,7 @@ class MailTest(unittest.TestCase):
                 'sender': test_sender,
                 'options': test_options,
             })
-            self.assertEquals(response.status_code, HTTPStatus.BAD_REQUEST)
+            self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
             self.assertFalse(send_notification_mock.called)
 
     @unittest.mock.patch('amundsen_application.api.mail.v0.send_notification')
@@ -147,5 +147,5 @@ class MailTest(unittest.TestCase):
             # generates error
             response = test.post('/api/mail/v0/notification', json=None)
 
-            self.assertEquals(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+            self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
             self.assertFalse(send_notification_mock.called)

--- a/tests/unit/api/metadata/test_v0.py
+++ b/tests/unit/api/metadata/test_v0.py
@@ -754,7 +754,7 @@ class MetadataTest(unittest.TestCase):
                     'tag': 'tag_5'
                 }
             )
-            self.assertEquals(response.status_code, HTTPStatus.OK)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
 
     @responses.activate
     def test_update_table_tags_delete(self) -> None:
@@ -773,7 +773,7 @@ class MetadataTest(unittest.TestCase):
                     'tag': 'tag_5'
                 }
             )
-            self.assertEquals(response.status_code, HTTPStatus.OK)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
 
     @responses.activate
     def test_update_dashboard_tags_put(self) -> None:
@@ -792,7 +792,7 @@ class MetadataTest(unittest.TestCase):
                     'tag': 'test_tag'
                 }
             )
-            self.assertEquals(response.status_code, HTTPStatus.OK)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
 
     @responses.activate
     def test_update_dashboard_tags_delete(self) -> None:
@@ -811,7 +811,7 @@ class MetadataTest(unittest.TestCase):
                     'tag': 'test_tag'
                 }
             )
-            self.assertEquals(response.status_code, HTTPStatus.OK)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
 
     @responses.activate
     def test_get_user_failure(self) -> None:
@@ -823,7 +823,7 @@ class MetadataTest(unittest.TestCase):
 
         with local_app.test_client() as test:
             response = test.get('/api/metadata/v0/user')
-            self.assertEquals(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+            self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
 
     @responses.activate
     def test_get_user_success(self) -> None:
@@ -836,8 +836,8 @@ class MetadataTest(unittest.TestCase):
         with local_app.test_client() as test:
             response = test.get('/api/metadata/v0/user', query_string=dict(user_id='testuser'))
             data = json.loads(response.data)
-            self.assertEquals(response.status_code, HTTPStatus.OK)
-            self.assertDictContainsSubset(self.expected_parsed_user, data.get('user'))
+            self.assertEqual(response.status_code, HTTPStatus.OK)
+            self.assertEqual(dict(data.get('user'), **self.expected_parsed_user), data.get('user'))
 
     @responses.activate
     def test_get_bookmark(self) -> None:
@@ -850,7 +850,7 @@ class MetadataTest(unittest.TestCase):
         with local_app.test_client() as test:
             response = test.get('/api/metadata/v0/user/bookmark')
             data = json.loads(response.data)
-            self.assertEquals(response.status_code, HTTPStatus.OK)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
             self.assertCountEqual(data.get('bookmarks'), self.expected_parsed_user_resources)
 
     @responses.activate
@@ -882,7 +882,7 @@ class MetadataTest(unittest.TestCase):
         with local_app.test_client() as test:
             response = test.get('/api/metadata/v0/user/bookmark', query_string=dict(user_id=specified_user))
             data = json.loads(response.data)
-            self.assertEquals(response.status_code, HTTPStatus.OK)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
             self.assertCountEqual(data.get('bookmarks'), self.expected_parsed_user_resources)
 
     @responses.activate
@@ -907,7 +907,7 @@ class MetadataTest(unittest.TestCase):
                     'key': key,
                 })
 
-            self.assertEquals(response.status_code, HTTPStatus.OK)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
 
     @responses.activate
     def test_delete_bookmark(self) -> None:
@@ -931,7 +931,7 @@ class MetadataTest(unittest.TestCase):
                     'key': key,
                 })
 
-            self.assertEquals(response.status_code, HTTPStatus.OK)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
 
     @responses.activate
     def test_get_user_read(self) -> None:
@@ -945,7 +945,7 @@ class MetadataTest(unittest.TestCase):
         with local_app.test_client() as test:
             response = test.get('/api/metadata/v0/user/read', query_string=dict(user_id=test_user))
             data = json.loads(response.data)
-            self.assertEquals(response.status_code, HTTPStatus.OK)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
             self.assertCountEqual(data.get('read'), self.expected_parsed_user_resources.get('table'))
 
     @responses.activate
@@ -960,7 +960,7 @@ class MetadataTest(unittest.TestCase):
         with local_app.test_client() as test:
             response = test.get('/api/metadata/v0/user/own', query_string=dict(user_id=test_user))
             data = json.loads(response.data)
-            self.assertEquals(response.status_code, HTTPStatus.OK)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
             self.assertCountEqual(data.get('own'), self.expected_parsed_user_resources)
 
     @responses.activate

--- a/tests/unit/log/test_action_log.py
+++ b/tests/unit/log/test_action_log.py
@@ -35,7 +35,7 @@ class ActionLogTest(unittest.TestCase):
                         'user': getpass.getuser()}
 
             for k, v in expected.items():
-                self.assertEquals(v, metrics.get(k))
+                self.assertEqual(v, metrics.get(k))
 
             self.assertTrue(metrics.get('start_epoch_ms') <= get_epoch_millisec())  # type: ignore
 


### PR DESCRIPTION
Signed-off-by: Wonyeong Choi <ciwnyg0815@gmail.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

- Since the `assertEquals` function has been deprecated, replaced it with the `assertEqual` function for all test files.
- Since the `assertDictContainsSubset` function has been deprecated, replaced it with `assertEqual` and `dict`function.

### Tests

Passed all existing unit tests

### Documentation

pytest doc about deprecated function
- https://docs.python.org/3.3/library/unittest.html#deprecated-aliases
- https://docs.python.org/2/library/unittest.html#unittest.TestCase.assertDictContainsSubset

### CheckList

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
