### PR TITLE
feat: Expose config for mTLS certificates.

### DIFF
--- a/amundsen_application/api/utils/request_utils.py
+++ b/amundsen_application/api/utils/request_utils.py
@@ -105,7 +105,7 @@ def request_wrapper(method: str, url: str, client, headers, timeout_sec: int, da
         else:
             raise Exception('Method not allowed: {}'.format(method))
     else:
-        with requests.Session() as s:
+        with build_session() as s:
             if method == 'DELETE':
                 return s.delete(url, headers=headers, timeout=timeout_sec)
             elif method == 'GET':
@@ -116,3 +116,14 @@ def request_wrapper(method: str, url: str, client, headers, timeout_sec: int, da
                 return s.put(url, headers=headers, timeout=timeout_sec, data=data)
             else:
                 raise Exception('Method not allowed: {}'.format(method))
+
+
+def build_session() -> requests.Session:
+    session = requests.Session()
+
+    cert = app.config.get('MTLS_CLIENT_CERT')
+    key = app.config.get('MTLS_CLIENT_KEY')
+    if cert is not None and key is not None:
+        session.cert = (cert, key)
+
+    return session

--- a/amundsen_application/config.py
+++ b/amundsen_application/config.py
@@ -100,6 +100,16 @@ class Config:
     # e.g: ACL_ENABLED_DASHBOARD_PREVIEW = {'ModePreview'}
     ACL_ENABLED_DASHBOARD_PREVIEW = set()  # type: Set[Optional[str]]
 
+    MTLS_CLIENT_CERT = os.getenv('MTLS_CLIENT_CERT')
+    """
+    Optional.
+    The path to a PEM formatted certificate to present when calling the metadata and search services.
+    MTLS_CLIENT_KEY must also be set.
+    """
+
+    MTLS_CLIENT_KEY = os.getenv('MTLS_CLIENT_KEY')
+    """Optional. The path to a PEM formatted key to use with the MTLS_CLIENT_CERT. MTLS_CLIENT_CERT must also be set."""
+
 
 class LocalConfig(Config):
     DEBUG = False


### PR DESCRIPTION
### Summary of Changes

Provide Env Vars to configure a client cert for mTLS.

A client certificate can be specified to present with requests to
metadata and search services for mTLS. The configuration is given
as a pair of paths to the PEM encoded cert and key files. This is
described in more detail in the requests documentation:
https://requests.readthedocs.io/en/master/user/advanced/#client-side-certificates

This assumes that the frontend should present the same client
cert to both the search and metadata services, which is consistent
with the idea that a client cert should uniquely identify the
service that is presenting it.

If the environment variables are not set, then the clients are
created as normal without any expectation of mTLS.

This addresses https://github.com/amundsen-io/amundsen/issues/754

### Tests

I did not see any existing tests around the API utils, and I did not know what approach to take for them.

### Documentation

There are Python docstrings on the fields added to the config.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
