### PR TITLE
feat: Pass user_id if available to popular tables endpoint

### DIFF
--- a/amundsen_application/api/metadata/v0.py
+++ b/amundsen_application/api/metadata/v0.py
@@ -26,7 +26,7 @@ metadata_blueprint = Blueprint('metadata', __name__, url_prefix='/api/metadata/v
 
 TABLE_ENDPOINT = '/table'
 LAST_INDEXED_ENDPOINT = '/latest_updated_ts'
-POPULAR_TABLES_ENDPOINT = '/popular_tables/'
+POPULAR_TABLES_ENDPOINT = '/popular_tables'
 TAGS_ENDPOINT = '/tags/'
 USER_ENDPOINT = '/user'
 DASHBOARD_ENDPOINT = '/dashboard'
@@ -56,9 +56,14 @@ def popular_tables() -> Response:
     https://github.com/lyft/amundsenmetadatalibrary/blob/master/metadata_service/api/popular_tables.py
     """
     try:
+        if app.config['AUTH_USER_METHOD']:
+            user_id = app.config['AUTH_USER_METHOD'](app).user_id
+        else:
+            user_id = ''
+
         service_base = app.config['METADATASERVICE_BASE']
         count = app.config['POPULAR_TABLE_COUNT']
-        url = f'{service_base}{POPULAR_TABLES_ENDPOINT}?limit={count}'
+        url = f'{service_base}{POPULAR_TABLES_ENDPOINT}/{user_id}?limit={count}'
 
         response = request_metadata(url=url)
         status_code = response.status_code

--- a/tests/unit/api/metadata/test_v0.py
+++ b/tests/unit/api/metadata/test_v0.py
@@ -474,7 +474,10 @@ class MetadataTest(unittest.TestCase):
         Test successful popular_tables request
         :return:
         """
-        responses.add(responses.GET, local_app.config['METADATASERVICE_BASE'] + POPULAR_TABLES_ENDPOINT,
+        mock_url = local_app.config['METADATASERVICE_BASE'] \
+            + POPULAR_TABLES_ENDPOINT \
+            + f'/{TEST_USER_ID}'
+        responses.add(responses.GET, mock_url,
                       json=self.mock_popular_tables, status=HTTPStatus.OK)
 
         with local_app.test_client() as test:
@@ -490,8 +493,11 @@ class MetadataTest(unittest.TestCase):
         returned to the React application
         :return:
         """
-        responses.add(responses.GET, local_app.config['METADATASERVICE_BASE'] + POPULAR_TABLES_ENDPOINT,
-                      json=self.mock_popular_tables, status=HTTPStatus.BAD_REQUEST)
+        mock_url = local_app.config['METADATASERVICE_BASE'] \
+            + POPULAR_TABLES_ENDPOINT \
+            + f'/{TEST_USER_ID}'
+        responses.add(responses.GET, mock_url, json=self.mock_popular_tables,
+                      status=HTTPStatus.BAD_REQUEST)
 
         with local_app.test_client() as test:
             response = test.get('/api/metadata/v0/popular_tables')
@@ -504,8 +510,11 @@ class MetadataTest(unittest.TestCase):
         results from the metadata service
         :return:
         """
-        responses.add(responses.GET, local_app.config['METADATASERVICE_BASE'] + POPULAR_TABLES_ENDPOINT,
-                      json={'popular_tables': None}, status=HTTPStatus.OK)
+        mock_url = local_app.config['METADATASERVICE_BASE'] \
+            + POPULAR_TABLES_ENDPOINT \
+            + f'/{TEST_USER_ID}'
+        responses.add(responses.GET, mock_url, json={'popular_tables': None},
+                      status=HTTPStatus.OK)
 
         with local_app.test_client() as test:
             response = test.get('/api/metadata/v0/popular_tables')


### PR DESCRIPTION
Signed-off-by: Josh Howard <joshthoward@gmail.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

Minor frontend service changes to be compatible with this [PR](https://github.com/amundsen-io/amundsenmetadatalibrary/pull/232). The idea is to pass the current authenticated user id to the metadata service to optionally customize the popular tables response. 

### Tests

Minor test updates to mock the popular tables endpoint w/ the authenticated user. 

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [-] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [-] PR includes a summary of changes, including screenshots of any UI changes.
- [-] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [-] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [-] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
