### PR TITLE
feat: Make 'schema' and 'database' clickable to initiate a search

### DIFF
--- a/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.spec.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.spec.tsx
@@ -1,81 +1,124 @@
-// // Copyright Contributors to the Amundsen project.
-// // SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
 
-// import * as React from 'react';
+import * as React from 'react';
+import { mocked } from 'ts-jest/utils';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { BrowserRouter } from 'react-router-dom';
 
-// import { mocked } from 'ts-jest/utils';
-// import { shallow } from 'enzyme';
+import { ResourceType } from 'interfaces/Resources';
+import {
+    getSourceDisplayName,
+    getDisplayNameByResource,
+} from 'config/config-utils';
+import globalState from 'fixtures/globalState';
+import TableHeaderBullets, { TableHeaderBulletsProps } from '.';
 
-// import { ResourceType } from 'interfaces/Resources';
-// import {
-//   getSourceDisplayName,
-//   getDisplayNameByResource,
-// } from 'config/config-utils';
-// import TableHeaderBullets, { TableHeaderBulletsProps } from '.';
+const MOCK_RESOURCE_DISPLAY_NAME = 'Test';
+const MOCK_DB_DISPLAY_NAME = 'AlsoTest';
+const TABLE_VIEW_TEXT = 'table view';
 
-// const MOCK_RESOURCE_DISPLAY_NAME = 'Test';
-// const MOCK_DB_DISPLAY_NAME = 'AlsoTest';
-// const TABLE_VIEW_TEXT = 'table view';
+jest.mock('config/config-utils', () => ({
+    getDisplayNameByResource: jest.fn(),
+    getSourceDisplayName: jest.fn(),
+}));
 
-// jest.mock('config/config-utils', () => ({
-//   getDisplayNameByResource: jest.fn(),
-//   getSourceDisplayName: jest.fn(),
-// }));
+let noDatabase;
+let noCluster;
+let noIsView;
 
-// describe('TableHeaderBullets', () => {
-//   const setup = (propOverrides?: Partial<TableHeaderBulletsProps>) => {
-//     const props: TableHeaderBulletsProps = {
-//       database: 'hive',
-//       cluster: 'main',
-//       isView: true,
-//       ...propOverrides,
-//     };
-//     const wrapper = shallow(<TableHeaderBullets {...props} />);
-//     return { props, wrapper };
-//   };
+const middlewares = [];
+const mockStore = configureStore(middlewares);
 
-//   describe('render', () => {
-//     let props: TableHeaderBulletsProps;
-//     let wrapper;
-//     let listElement;
-//     beforeAll(() => {
-//       mocked(getSourceDisplayName).mockImplementation(
-//         () => MOCK_DB_DISPLAY_NAME
-//       );
-//       mocked(getDisplayNameByResource).mockImplementation(
-//         () => MOCK_RESOURCE_DISPLAY_NAME
-//       );
-//       const setupResult = setup();
-//       props = setupResult.props;
-//       wrapper = setupResult.wrapper;
-//       listElement = wrapper.find('ul');
-//     });
+const setup = (propOverrides?: Partial<TableHeaderBulletsProps>) => {
+    const props = {
+        database: 'hive',
+        cluster: 'main',
+        isView: true,
+        ...propOverrides,
+    };
+    const testState = globalState;
+    const wrapper = mount<TableHeaderBulletsProps>(
+        <Provider store={mockStore(testState)}>
+            <BrowserRouter>
+                <TableHeaderBullets {...props} />
+            </BrowserRouter>
+        </Provider>
+    );
+    return { props, wrapper };
+};
 
-//     it('renders a list with correct class', () => {
-//       expect(listElement.props().className).toEqual('header-bullets');
-//     });
+describe('TableHeaderBullets', () => {
+    describe('when no props passed', () => {
+        const { wrapper } = setup({
+            database: noDatabase,
+            cluster: noCluster,
+            isView: noIsView,
+        });
+        it('renders TableHeaderBullets element', () => {
+            const actual = wrapper.find('.header-bullets').length;
+            const expected = 1;
 
-//     it('renders a list with resource display name', () => {
-//       expect(getDisplayNameByResource).toHaveBeenCalledWith(ResourceType.table);
-//       expect(listElement.find('li').at(0).text()).toEqual(
-//         MOCK_RESOURCE_DISPLAY_NAME
-//       );
-//     });
+            expect(actual).toEqual(expected);
+        });
+        it('renders TableHeaderBullets list with default props', () => {
+            const actualDatabase = wrapper.find('ul').find('li').at(0).text();
+            const expectedDatabase = '';
+            const actualCluster = wrapper.find('ul').find('li').at(1).text();
+            const expectedCluster = '';
+            const actualIsView = wrapper.find('ul').find('li').at(2).text();
+            const expectedIsView = '';
 
-//     it('renders a list with database display name', () => {
-//       expect(getSourceDisplayName).toHaveBeenCalledWith(
-//         props.database,
-//         ResourceType.table
-//       );
-//       expect(listElement.find('li').at(1).text()).toEqual(MOCK_DB_DISPLAY_NAME);
-//     });
+            expect(actualDatabase).toEqual(expectedDatabase);
+            expect(actualCluster).toEqual(expectedCluster);
+            expect(actualIsView).toEqual(expectedIsView);
+        });
+    });
 
-//     it('renders a list with cluster', () => {
-//       expect(listElement.find('li').at(2).text()).toEqual(props.cluster);
-//     });
+    describe('when props are defined', () => {
+        let props;
+        let wrapper;
 
-//     it('renders a list with table view', () => {
-//       expect(listElement.find('li').at(3).text()).toEqual(TABLE_VIEW_TEXT);
-//     });
-//   });
-// });
+        beforeAll(() => {
+            mocked(getSourceDisplayName).mockImplementation(
+                () => MOCK_DB_DISPLAY_NAME
+            );
+            mocked(getDisplayNameByResource).mockImplementation(
+                () => MOCK_RESOURCE_DISPLAY_NAME
+            );
+            const setupResult = setup();
+            props = setupResult.props;
+            wrapper = setupResult.wrapper;
+        });
+
+        it('renders TableHeaderBullets element', () => {
+            const actual = wrapper.find('.header-bullets').length;
+            const expected = 1;
+
+            expect(actual).toEqual(expected);
+        });
+        it('renders a list with resource display name', () => {
+            console.log(wrapper.debug());
+            expect(getDisplayNameByResource).toHaveBeenCalledWith(ResourceType.table);
+            expect(wrapper.find('ul').find('li').at(0).text()).toEqual(
+                MOCK_RESOURCE_DISPLAY_NAME
+            );
+        });
+        it('renders a list with database display name', () => {
+            expect(getSourceDisplayName).toHaveBeenCalledWith(
+                props.database,
+                ResourceType.table
+            );
+            expect(wrapper.find('ul').find('li').at(1).text()).toEqual(MOCK_DB_DISPLAY_NAME);
+        });
+        it('renders a list with cluster', () => {
+            expect(wrapper.find('ul').find('li').at(2).text()).toEqual(props.cluster);
+        });
+        it('renders a list with table view', () => {
+            expect(wrapper.find('ul').find('li').at(3).text()).toEqual(TABLE_VIEW_TEXT);
+        });
+    });
+
+});

--- a/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.spec.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.spec.tsx
@@ -10,8 +10,8 @@ import { BrowserRouter } from 'react-router-dom';
 
 import { ResourceType } from 'interfaces/Resources';
 import {
-    getSourceDisplayName,
-    getDisplayNameByResource,
+  getSourceDisplayName,
+  getDisplayNameByResource,
 } from 'config/config-utils';
 import globalState from 'fixtures/globalState';
 import TableHeaderBullets, { TableHeaderBulletsProps } from '.';
@@ -21,8 +21,8 @@ const MOCK_DB_DISPLAY_NAME = 'AlsoTest';
 const TABLE_VIEW_TEXT = 'table view';
 
 jest.mock('config/config-utils', () => ({
-    getDisplayNameByResource: jest.fn(),
-    getSourceDisplayName: jest.fn(),
+  getDisplayNameByResource: jest.fn(),
+  getSourceDisplayName: jest.fn(),
 }));
 
 let noDatabase;
@@ -33,92 +33,95 @@ const middlewares = [];
 const mockStore = configureStore(middlewares);
 
 const setup = (propOverrides?: Partial<TableHeaderBulletsProps>) => {
-    const props = {
-        database: 'hive',
-        cluster: 'main',
-        isView: true,
-        ...propOverrides,
-    };
-    const testState = globalState;
-    const wrapper = mount<TableHeaderBulletsProps>(
-        <Provider store={mockStore(testState)}>
-            <BrowserRouter>
-                <TableHeaderBullets {...props} />
-            </BrowserRouter>
-        </Provider>
-    );
-    return { props, wrapper };
+  const props = {
+    database: 'hive',
+    cluster: 'main',
+    isView: true,
+    ...propOverrides,
+  };
+  const testState = globalState;
+  const wrapper = mount<TableHeaderBulletsProps>(
+    <Provider store={mockStore(testState)}>
+      <BrowserRouter>
+        <TableHeaderBullets {...props} />
+      </BrowserRouter>
+    </Provider>
+  );
+  return { props, wrapper };
 };
 
 describe('TableHeaderBullets', () => {
-    describe('when no props passed', () => {
-        const { wrapper } = setup({
-            database: noDatabase,
-            cluster: noCluster,
-            isView: noIsView,
-        });
-        it('renders TableHeaderBullets element', () => {
-            const actual = wrapper.find('.header-bullets').length;
-            const expected = 1;
+  describe('when no props passed', () => {
+    const { wrapper } = setup({
+      database: noDatabase,
+      cluster: noCluster,
+      isView: noIsView,
+    });
+    it('renders TableHeaderBullets element', () => {
+      const actual = wrapper.find('.header-bullets').length;
+      const expected = 1;
 
-            expect(actual).toEqual(expected);
-        });
-        it('renders TableHeaderBullets list with default props', () => {
-            const actualDatabase = wrapper.find('ul').find('li').at(0).text();
-            const expectedDatabase = '';
-            const actualCluster = wrapper.find('ul').find('li').at(1).text();
-            const expectedCluster = '';
-            const actualIsView = wrapper.find('ul').find('li').at(2).text();
-            const expectedIsView = '';
+      expect(actual).toEqual(expected);
+    });
+    it('renders TableHeaderBullets list with default props', () => {
+      const actualDatabase = wrapper.find('ul').find('li').at(0).text();
+      const expectedDatabase = '';
+      const actualCluster = wrapper.find('ul').find('li').at(1).text();
+      const expectedCluster = '';
+      const actualIsView = wrapper.find('ul').find('li').at(2).text();
+      const expectedIsView = '';
 
-            expect(actualDatabase).toEqual(expectedDatabase);
-            expect(actualCluster).toEqual(expectedCluster);
-            expect(actualIsView).toEqual(expectedIsView);
-        });
+      expect(actualDatabase).toEqual(expectedDatabase);
+      expect(actualCluster).toEqual(expectedCluster);
+      expect(actualIsView).toEqual(expectedIsView);
+    });
+  });
+
+  describe('when props are defined', () => {
+    let props;
+    let wrapper;
+
+    beforeAll(() => {
+      mocked(getSourceDisplayName).mockImplementation(
+        () => MOCK_DB_DISPLAY_NAME
+      );
+      mocked(getDisplayNameByResource).mockImplementation(
+        () => MOCK_RESOURCE_DISPLAY_NAME
+      );
+      const setupResult = setup();
+      props = setupResult.props;
+      wrapper = setupResult.wrapper;
     });
 
-    describe('when props are defined', () => {
-        let props;
-        let wrapper;
+    it('renders TableHeaderBullets element', () => {
+      const actual = wrapper.find('.header-bullets').length;
+      const expected = 1;
 
-        beforeAll(() => {
-            mocked(getSourceDisplayName).mockImplementation(
-                () => MOCK_DB_DISPLAY_NAME
-            );
-            mocked(getDisplayNameByResource).mockImplementation(
-                () => MOCK_RESOURCE_DISPLAY_NAME
-            );
-            const setupResult = setup();
-            props = setupResult.props;
-            wrapper = setupResult.wrapper;
-        });
-
-        it('renders TableHeaderBullets element', () => {
-            const actual = wrapper.find('.header-bullets').length;
-            const expected = 1;
-
-            expect(actual).toEqual(expected);
-        });
-        it('renders a list with resource display name', () => {
-            console.log(wrapper.debug());
-            expect(getDisplayNameByResource).toHaveBeenCalledWith(ResourceType.table);
-            expect(wrapper.find('ul').find('li').at(0).text()).toEqual(
-                MOCK_RESOURCE_DISPLAY_NAME
-            );
-        });
-        it('renders a list with database display name', () => {
-            expect(getSourceDisplayName).toHaveBeenCalledWith(
-                props.database,
-                ResourceType.table
-            );
-            expect(wrapper.find('ul').find('li').at(1).text()).toEqual(MOCK_DB_DISPLAY_NAME);
-        });
-        it('renders a list with cluster', () => {
-            expect(wrapper.find('ul').find('li').at(2).text()).toEqual(props.cluster);
-        });
-        it('renders a list with table view', () => {
-            expect(wrapper.find('ul').find('li').at(3).text()).toEqual(TABLE_VIEW_TEXT);
-        });
+      expect(actual).toEqual(expected);
     });
-
+    it('renders a list with resource display name', () => {
+      console.log(wrapper.debug());
+      expect(getDisplayNameByResource).toHaveBeenCalledWith(ResourceType.table);
+      expect(wrapper.find('ul').find('li').at(0).text()).toEqual(
+        MOCK_RESOURCE_DISPLAY_NAME
+      );
+    });
+    it('renders a list with database display name', () => {
+      expect(getSourceDisplayName).toHaveBeenCalledWith(
+        props.database,
+        ResourceType.table
+      );
+      expect(wrapper.find('ul').find('li').at(1).text()).toEqual(
+        MOCK_DB_DISPLAY_NAME
+      );
+    });
+    it('renders a list with cluster', () => {
+      expect(wrapper.find('ul').find('li').at(2).text()).toEqual(props.cluster);
+    });
+    it('renders a list with table view', () => {
+      expect(wrapper.find('ul').find('li').at(3).text()).toEqual(
+        TABLE_VIEW_TEXT
+      );
+    });
+  });
 });

--- a/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.spec.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.spec.tsx
@@ -1,81 +1,81 @@
-// Copyright Contributors to the Amundsen project.
-// SPDX-License-Identifier: Apache-2.0
+// // Copyright Contributors to the Amundsen project.
+// // SPDX-License-Identifier: Apache-2.0
 
-import * as React from 'react';
+// import * as React from 'react';
 
-import { mocked } from 'ts-jest/utils';
-import { shallow } from 'enzyme';
+// import { mocked } from 'ts-jest/utils';
+// import { shallow } from 'enzyme';
 
-import { ResourceType } from 'interfaces/Resources';
-import {
-  getSourceDisplayName,
-  getDisplayNameByResource,
-} from 'config/config-utils';
-import TableHeaderBullets, { TableHeaderBulletsProps } from '.';
+// import { ResourceType } from 'interfaces/Resources';
+// import {
+//   getSourceDisplayName,
+//   getDisplayNameByResource,
+// } from 'config/config-utils';
+// import TableHeaderBullets, { TableHeaderBulletsProps } from '.';
 
-const MOCK_RESOURCE_DISPLAY_NAME = 'Test';
-const MOCK_DB_DISPLAY_NAME = 'AlsoTest';
-const TABLE_VIEW_TEXT = 'table view';
+// const MOCK_RESOURCE_DISPLAY_NAME = 'Test';
+// const MOCK_DB_DISPLAY_NAME = 'AlsoTest';
+// const TABLE_VIEW_TEXT = 'table view';
 
-jest.mock('config/config-utils', () => ({
-  getDisplayNameByResource: jest.fn(),
-  getSourceDisplayName: jest.fn(),
-}));
+// jest.mock('config/config-utils', () => ({
+//   getDisplayNameByResource: jest.fn(),
+//   getSourceDisplayName: jest.fn(),
+// }));
 
-describe('TableHeaderBullets', () => {
-  const setup = (propOverrides?: Partial<TableHeaderBulletsProps>) => {
-    const props: TableHeaderBulletsProps = {
-      database: 'hive',
-      cluster: 'main',
-      isView: true,
-      ...propOverrides,
-    };
-    const wrapper = shallow(<TableHeaderBullets {...props} />);
-    return { props, wrapper };
-  };
+// describe('TableHeaderBullets', () => {
+//   const setup = (propOverrides?: Partial<TableHeaderBulletsProps>) => {
+//     const props: TableHeaderBulletsProps = {
+//       database: 'hive',
+//       cluster: 'main',
+//       isView: true,
+//       ...propOverrides,
+//     };
+//     const wrapper = shallow(<TableHeaderBullets {...props} />);
+//     return { props, wrapper };
+//   };
 
-  describe('render', () => {
-    let props: TableHeaderBulletsProps;
-    let wrapper;
-    let listElement;
-    beforeAll(() => {
-      mocked(getSourceDisplayName).mockImplementation(
-        () => MOCK_DB_DISPLAY_NAME
-      );
-      mocked(getDisplayNameByResource).mockImplementation(
-        () => MOCK_RESOURCE_DISPLAY_NAME
-      );
-      const setupResult = setup();
-      props = setupResult.props;
-      wrapper = setupResult.wrapper;
-      listElement = wrapper.find('ul');
-    });
+//   describe('render', () => {
+//     let props: TableHeaderBulletsProps;
+//     let wrapper;
+//     let listElement;
+//     beforeAll(() => {
+//       mocked(getSourceDisplayName).mockImplementation(
+//         () => MOCK_DB_DISPLAY_NAME
+//       );
+//       mocked(getDisplayNameByResource).mockImplementation(
+//         () => MOCK_RESOURCE_DISPLAY_NAME
+//       );
+//       const setupResult = setup();
+//       props = setupResult.props;
+//       wrapper = setupResult.wrapper;
+//       listElement = wrapper.find('ul');
+//     });
 
-    it('renders a list with correct class', () => {
-      expect(listElement.props().className).toEqual('header-bullets');
-    });
+//     it('renders a list with correct class', () => {
+//       expect(listElement.props().className).toEqual('header-bullets');
+//     });
 
-    it('renders a list with resource display name', () => {
-      expect(getDisplayNameByResource).toHaveBeenCalledWith(ResourceType.table);
-      expect(listElement.find('li').at(0).text()).toEqual(
-        MOCK_RESOURCE_DISPLAY_NAME
-      );
-    });
+//     it('renders a list with resource display name', () => {
+//       expect(getDisplayNameByResource).toHaveBeenCalledWith(ResourceType.table);
+//       expect(listElement.find('li').at(0).text()).toEqual(
+//         MOCK_RESOURCE_DISPLAY_NAME
+//       );
+//     });
 
-    it('renders a list with database display name', () => {
-      expect(getSourceDisplayName).toHaveBeenCalledWith(
-        props.database,
-        ResourceType.table
-      );
-      expect(listElement.find('li').at(1).text()).toEqual(MOCK_DB_DISPLAY_NAME);
-    });
+//     it('renders a list with database display name', () => {
+//       expect(getSourceDisplayName).toHaveBeenCalledWith(
+//         props.database,
+//         ResourceType.table
+//       );
+//       expect(listElement.find('li').at(1).text()).toEqual(MOCK_DB_DISPLAY_NAME);
+//     });
 
-    it('renders a list with cluster', () => {
-      expect(listElement.find('li').at(2).text()).toEqual(props.cluster);
-    });
+//     it('renders a list with cluster', () => {
+//       expect(listElement.find('li').at(2).text()).toEqual(props.cluster);
+//     });
 
-    it('renders a list with table view', () => {
-      expect(listElement.find('li').at(3).text()).toEqual(TABLE_VIEW_TEXT);
-    });
-  });
-});
+//     it('renders a list with table view', () => {
+//       expect(listElement.find('li').at(3).text()).toEqual(TABLE_VIEW_TEXT);
+//     });
+//   });
+// });

--- a/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
@@ -1,42 +1,86 @@
-// Copyright Contributors to the Amundsen project.
-// SPDX-License-Identifier: Apache-2.0
+/*
+  This file is copy-pasted from the upstream file at the same path and of the
+  same name. It has been modified to include a Lyft specific UI decision.
+
+  This choice requires manually maintaining these files, and they are not unit tested.
+
+  Before defaulting to this pattern for other components, first consider if an
+  application configuration would be appropriate and useful for other community
+  use cases.
+*/
 
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 
-import {
-  getDisplayNameByResource,
-  getSourceDisplayName,
-} from 'config/config-utils';
+import { getDisplayNameByResource, getSourceDisplayName } from 'config/config-utils';
+
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import { updateSearchState } from 'ducks/search/reducer';
+import { UpdateSearchStateRequest } from 'ducks/search/types';
+import { logClick } from 'ducks/utilMethods';
 
 import { ResourceType } from 'interfaces/Resources';
 
 import { TABLE_VIEW_TEXT } from './constants';
 
-export interface TableHeaderBulletsProps {
+export type TableHeaderBulletsProps = HeaderBulletsProps & DispatchFromProps;
+
+export interface HeaderBulletsProps {
   cluster: string;
   database: string;
   isView: boolean;
 }
+export interface DispatchFromProps {
+  searchDatabase: (databaseText: string) => UpdateSearchStateRequest;
+}
 
-const TableHeaderBullets: React.FC<TableHeaderBulletsProps> = ({
-  cluster,
-  database,
-  isView,
-}: TableHeaderBulletsProps) => {
-  return (
-    <ul className="header-bullets">
-      <li>{getDisplayNameByResource(ResourceType.table)}</li>
-      <li>{getSourceDisplayName(database, ResourceType.table)}</li>
-      <li>{cluster}</li>
-      {isView && <li>{TABLE_VIEW_TEXT}</li>}
-    </ul>
+export class TableHeaderBullets extends React.Component<TableHeaderBulletsProps> {
+
+  handleClick = (e) => {
+    const databaseText = this.props.database;
+    logClick(e, {
+      target_type: 'database',
+      label: databaseText,
+    });
+    this.props.searchDatabase(databaseText);
+  };
+  render() {
+    return (
+      <ul className="header-bullets" >
+        <li>{getDisplayNameByResource(ResourceType.table)} </li>
+        <li><Link to='/search' onClick={this.handleClick}>{getSourceDisplayName(this.props.database, ResourceType.table)}</Link></li>
+        <li>{this.props.cluster}</li>
+        {this.props.isView && <li>{TABLE_VIEW_TEXT}</li>}
+      </ul >
+    );
+  }
+
+};
+
+// TableHeaderBullets.defaultProps = {
+//   cluster: '',
+//   database: '',
+//   isView: false,
+// };
+
+export const mapDispatchToProps = (dispatch: any) => {
+  return bindActionCreators(
+    {
+      searchDatabase: (databaseText: string) =>
+        updateSearchState({
+          filters: {
+            [ResourceType.table]: { database: databaseText },
+          },
+          submitSearch: true,
+        }),
+    },
+    dispatch
   );
 };
 
-TableHeaderBullets.defaultProps = {
-  cluster: '',
-  database: '',
-  isView: false,
-};
-
-export default TableHeaderBullets;
+export default connect<null, DispatchFromProps, HeaderBulletsProps>(
+  null,
+  mapDispatchToProps
+)(TableHeaderBullets);

--- a/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
@@ -12,7 +12,10 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 
-import { getDisplayNameByResource, getSourceDisplayName } from 'config/config-utils';
+import {
+  getDisplayNameByResource,
+  getSourceDisplayName,
+} from 'config/config-utils';
 
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -25,8 +28,6 @@ import { ResourceType } from 'interfaces/Resources';
 
 import { TABLE_VIEW_TEXT } from './constants';
 
-export type TableHeaderBulletsProps = HeaderBulletsProps & DispatchFromProps;
-
 export interface HeaderBulletsProps {
   cluster: string;
   database: string;
@@ -36,8 +37,11 @@ export interface DispatchFromProps {
   searchDatabase: (databaseText: string) => UpdateSearchStateRequest;
 }
 
-export class TableHeaderBullets extends React.Component<TableHeaderBulletsProps> {
+export type TableHeaderBulletsProps = HeaderBulletsProps & DispatchFromProps;
 
+export class TableHeaderBullets extends React.Component<
+  TableHeaderBulletsProps
+  > {
   handleClick = (e) => {
     const databaseText = this.props.database;
     logClick(e, {
@@ -46,18 +50,27 @@ export class TableHeaderBullets extends React.Component<TableHeaderBulletsProps>
     });
     this.props.searchDatabase(databaseText);
   };
+
   render() {
+    const isViewCheck =
+      this.props.isView == undefined ? false : this.props.isView;
     return (
-      <ul className="header-bullets" >
-        <li>{getDisplayNameByResource(ResourceType.table)} </li>
-        <li><Link to='/search' onClick={this.handleClick}>{getSourceDisplayName(this.props.database || '', ResourceType.table)}</Link></li>
+      <ul className="header-bullets">
+        <li>{getDisplayNameByResource(ResourceType.table)}</li>
+        <li>
+          <Link to="/search" onClick={this.handleClick}>
+            {getSourceDisplayName(
+              this.props.database || '',
+              ResourceType.table
+            )}
+          </Link>
+        </li>
         <li>{this.props.cluster || ''}</li>
-        {this.props.isView && <li>{TABLE_VIEW_TEXT}</li>}
-      </ul >
+        {isViewCheck && <li>{TABLE_VIEW_TEXT}</li>}
+      </ul>
     );
   }
-
-};
+}
 
 export const mapDispatchToProps = (dispatch: any) => {
   return bindActionCreators(

--- a/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
@@ -33,7 +33,7 @@ export type TableHeaderBulletsProps = HeaderBulletsProps & DispatchFromProps;
 
 export class TableHeaderBullets extends React.Component<
   TableHeaderBulletsProps
-  > {
+  >{
   handleClick = (e) => {
     const databaseText = this.props.database;
     logClick(e, {

--- a/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
@@ -41,7 +41,7 @@ export type TableHeaderBulletsProps = HeaderBulletsProps & DispatchFromProps;
 
 export class TableHeaderBullets extends React.Component<
   TableHeaderBulletsProps
-> {
+  > {
   handleClick = (e) => {
     const databaseText = this.props.database;
     logClick(e, {
@@ -53,7 +53,7 @@ export class TableHeaderBullets extends React.Component<
 
   render() {
     const isViewCheck =
-      this.props.isView == undefined ? false : this.props.isView;
+      this.props.isView === undefined ? false : this.props.isView;
     return (
       <ul className="header-bullets">
         <li>{getDisplayNameByResource(ResourceType.table)}</li>

--- a/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
@@ -50,20 +50,14 @@ export class TableHeaderBullets extends React.Component<TableHeaderBulletsProps>
     return (
       <ul className="header-bullets" >
         <li>{getDisplayNameByResource(ResourceType.table)} </li>
-        <li><Link to='/search' onClick={this.handleClick}>{getSourceDisplayName(this.props.database, ResourceType.table)}</Link></li>
-        <li>{this.props.cluster}</li>
+        <li><Link to='/search' onClick={this.handleClick}>{getSourceDisplayName(this.props.database || '', ResourceType.table)}</Link></li>
+        <li>{this.props.cluster || ''}</li>
         {this.props.isView && <li>{TABLE_VIEW_TEXT}</li>}
       </ul >
     );
   }
 
 };
-
-// TableHeaderBullets.defaultProps = {
-//   cluster: '',
-//   database: '',
-//   isView: false,
-// };
 
 export const mapDispatchToProps = (dispatch: any) => {
   return bindActionCreators(

--- a/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
@@ -41,7 +41,7 @@ export type TableHeaderBulletsProps = HeaderBulletsProps & DispatchFromProps;
 
 export class TableHeaderBullets extends React.Component<
   TableHeaderBulletsProps
-  > {
+> {
   handleClick = (e) => {
     const databaseText = this.props.database;
     logClick(e, {

--- a/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
@@ -31,9 +31,7 @@ export interface DispatchFromProps {
 
 export type TableHeaderBulletsProps = HeaderBulletsProps & DispatchFromProps;
 
-export class TableHeaderBullets extends React.Component<
-  TableHeaderBulletsProps
-  >{
+export class TableHeaderBullets extends React.Component<TableHeaderBulletsProps>{
   handleClick = (e) => {
     const databaseText = this.props.database;
     logClick(e, {

--- a/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
@@ -68,7 +68,7 @@ export const mapDispatchToProps = (dispatch: any) => {
       searchDatabase: (databaseText: string) =>
         updateSearchState({
           filters: {
-            [ResourceType.table]: { database: databaseText },
+            [ResourceType.table]: { database: { [databaseText]: true } },
           },
           submitSearch: true,
         }),

--- a/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
@@ -1,13 +1,5 @@
-/*
-  This file is copy-pasted from the upstream file at the same path and of the
-  same name. It has been modified to include a Lyft specific UI decision.
-
-  This choice requires manually maintaining these files, and they are not unit tested.
-
-  Before defaulting to this pattern for other components, first consider if an
-  application configuration would be appropriate and useful for other community
-  use cases.
-*/
+// Copyright Contributors to the Amundsen project.	/*
+// SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
 import { Link } from 'react-router-dom';

--- a/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
@@ -31,7 +31,9 @@ export interface DispatchFromProps {
 
 export type TableHeaderBulletsProps = HeaderBulletsProps & DispatchFromProps;
 
-export class TableHeaderBullets extends React.Component<TableHeaderBulletsProps>{
+export class TableHeaderBullets extends React.Component<
+  TableHeaderBulletsProps
+> {
   handleClick = (e) => {
     const databaseText = this.props.database;
     logClick(e, {

--- a/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -41,6 +41,7 @@ const setup = (
     tableData: tableMetadata,
     getTableData: jest.fn(),
     openRequestDescriptionDialog: jest.fn(),
+    searchSchema: jest.fn(),
     ...routerProps,
     ...propOverrides,
   };

--- a/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -1,98 +1,98 @@
-// // Copyright Contributors to the Amundsen project.
-// // SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
 
-// import * as React from 'react';
-// import * as History from 'history';
-// import { mount, shallow } from 'enzyme';
-// import { mocked } from 'ts-jest/utils';
+import * as React from 'react';
+import * as History from 'history';
+import { mount, shallow } from 'enzyme';
+import { mocked } from 'ts-jest/utils';
 
-// import { getMockRouterProps } from 'fixtures/mockRouter';
-// import { tableMetadata } from 'fixtures/metadata/table';
+import { getMockRouterProps } from 'fixtures/mockRouter';
+import { tableMetadata } from 'fixtures/metadata/table';
 
-// import LoadingSpinner from 'components/common/LoadingSpinner';
-// import TabsComponent from 'components/common/TabsComponent';
+import LoadingSpinner from 'components/common/LoadingSpinner';
+import TabsComponent from 'components/common/TabsComponent';
 
-// import { indexDashboardsEnabled } from 'config/config-utils';
-// import { TableDetail, TableDetailProps, MatchProps } from '.';
+import { indexDashboardsEnabled } from 'config/config-utils';
+import { TableDetail, TableDetailProps, MatchProps } from '.';
 
-// jest.mock('config/config-utils', () => ({
-//   indexDashboardsEnabled: jest.fn(),
-//   getTableSortCriterias: jest.fn(),
-// }));
+jest.mock('config/config-utils', () => ({
+  indexDashboardsEnabled: jest.fn(),
+  getTableSortCriterias: jest.fn(),
+}));
 
-// const setup = (
-//   propOverrides?: Partial<TableDetailProps>,
-//   location?: Partial<History.Location>
-// ) => {
-//   const routerProps = getMockRouterProps<MatchProps>(
-//     {
-//       cluster: 'gold',
-//       database: 'hive',
-//       schema: 'base',
-//       table: 'rides',
-//     },
-//     location
-//   );
-//   const props = {
-//     isLoading: false,
-//     isLoadingDashboards: false,
-//     numRelatedDashboards: 0,
-//     statusCode: 200,
-//     tableData: tableMetadata,
-//     getTableData: jest.fn(),
-//     openRequestDescriptionDialog: jest.fn(),
-//     ...routerProps,
-//     ...propOverrides,
-//   };
-//   const wrapper = mount<TableDetail>(<TableDetail {...props} />);
+const setup = (
+  propOverrides?: Partial<TableDetailProps>,
+  location?: Partial<History.Location>
+) => {
+  const routerProps = getMockRouterProps<MatchProps>(
+    {
+      cluster: 'gold',
+      database: 'hive',
+      schema: 'base',
+      table: 'rides',
+    },
+    location
+  );
+  const props = {
+    isLoading: false,
+    isLoadingDashboards: false,
+    numRelatedDashboards: 0,
+    statusCode: 200,
+    tableData: tableMetadata,
+    getTableData: jest.fn(),
+    openRequestDescriptionDialog: jest.fn(),
+    ...routerProps,
+    ...propOverrides,
+  };
+  const wrapper = mount<TableDetail>(<TableDetail {...props} />);
 
-//   return { props, wrapper };
-// };
+  return { props, wrapper };
+};
 
-// describe('TableDetail', () => {
-//   describe('renderTabs', () => {
-//     let wrapper;
-//     beforeAll(() => {
-//       wrapper = setup().wrapper;
-//     });
-//     it('renders one tab when dashboards are not enabled', () => {
-//       mocked(indexDashboardsEnabled).mockImplementation(() => false);
-//       const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
-//       expect(content.find(TabsComponent).props().tabs.length).toEqual(1);
-//     });
+describe('TableDetail', () => {
+  describe('renderTabs', () => {
+    let wrapper;
+    beforeAll(() => {
+      wrapper = setup().wrapper;
+    });
+    it('renders one tab when dashboards are not enabled', () => {
+      mocked(indexDashboardsEnabled).mockImplementation(() => false);
+      const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
+      expect(content.find(TabsComponent).props().tabs.length).toEqual(1);
+    });
 
-//     it('renders two tabs when dashboards are enabled', () => {
-//       mocked(indexDashboardsEnabled).mockImplementation(() => true);
-//       const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
-//       expect(content.find(TabsComponent).props().tabs.length).toEqual(2);
-//     });
-//   });
+    it('renders two tabs when dashboards are enabled', () => {
+      mocked(indexDashboardsEnabled).mockImplementation(() => true);
+      const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
+      expect(content.find(TabsComponent).props().tabs.length).toEqual(2);
+    });
+  });
 
-//   describe('render', () => {
-//     it('should render without problems', () => {
-//       expect(() => {
-//         setup();
-//       }).not.toThrow();
-//     });
+  describe('render', () => {
+    it('should render without problems', () => {
+      expect(() => {
+        setup();
+      }).not.toThrow();
+    });
 
-//     it('should render the Loading Spinner', () => {
-//       const { wrapper } = setup();
-//       const expected = 1;
-//       const actual = wrapper.find(LoadingSpinner).length;
+    it('should render the Loading Spinner', () => {
+      const { wrapper } = setup();
+      const expected = 1;
+      const actual = wrapper.find(LoadingSpinner).length;
 
-//       expect(actual).toEqual(expected);
-//     });
-//   });
+      expect(actual).toEqual(expected);
+    });
+  });
 
-//   describe('lifecycle', () => {
-//     describe('when mounted', () => {
-//       it('calls loadDashboard with uri from state', () => {
-//         const { props } = setup();
-//         const expected = 1;
-//         const actual = (props.getTableData as jest.Mock).mock.calls.length;
+  describe('lifecycle', () => {
+    describe('when mounted', () => {
+      it('calls loadDashboard with uri from state', () => {
+        const { props } = setup();
+        const expected = 1;
+        const actual = (props.getTableData as jest.Mock).mock.calls.length;
 
-//         expect(actual).toEqual(expected);
-//       });
-//     });
-//   });
-// });
+        expect(actual).toEqual(expected);
+      });
+    });
+  });
+});

--- a/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -1,98 +1,98 @@
-// Copyright Contributors to the Amundsen project.
-// SPDX-License-Identifier: Apache-2.0
+// // Copyright Contributors to the Amundsen project.
+// // SPDX-License-Identifier: Apache-2.0
 
-import * as React from 'react';
-import * as History from 'history';
-import { mount, shallow } from 'enzyme';
-import { mocked } from 'ts-jest/utils';
+// import * as React from 'react';
+// import * as History from 'history';
+// import { mount, shallow } from 'enzyme';
+// import { mocked } from 'ts-jest/utils';
 
-import { getMockRouterProps } from 'fixtures/mockRouter';
-import { tableMetadata } from 'fixtures/metadata/table';
+// import { getMockRouterProps } from 'fixtures/mockRouter';
+// import { tableMetadata } from 'fixtures/metadata/table';
 
-import LoadingSpinner from 'components/common/LoadingSpinner';
-import TabsComponent from 'components/common/TabsComponent';
+// import LoadingSpinner from 'components/common/LoadingSpinner';
+// import TabsComponent from 'components/common/TabsComponent';
 
-import { indexDashboardsEnabled } from 'config/config-utils';
-import { TableDetail, TableDetailProps, MatchProps } from '.';
+// import { indexDashboardsEnabled } from 'config/config-utils';
+// import { TableDetail, TableDetailProps, MatchProps } from '.';
 
-jest.mock('config/config-utils', () => ({
-  indexDashboardsEnabled: jest.fn(),
-  getTableSortCriterias: jest.fn(),
-}));
+// jest.mock('config/config-utils', () => ({
+//   indexDashboardsEnabled: jest.fn(),
+//   getTableSortCriterias: jest.fn(),
+// }));
 
-const setup = (
-  propOverrides?: Partial<TableDetailProps>,
-  location?: Partial<History.Location>
-) => {
-  const routerProps = getMockRouterProps<MatchProps>(
-    {
-      cluster: 'gold',
-      database: 'hive',
-      schema: 'base',
-      table: 'rides',
-    },
-    location
-  );
-  const props = {
-    isLoading: false,
-    isLoadingDashboards: false,
-    numRelatedDashboards: 0,
-    statusCode: 200,
-    tableData: tableMetadata,
-    getTableData: jest.fn(),
-    openRequestDescriptionDialog: jest.fn(),
-    ...routerProps,
-    ...propOverrides,
-  };
-  const wrapper = mount<TableDetail>(<TableDetail {...props} />);
+// const setup = (
+//   propOverrides?: Partial<TableDetailProps>,
+//   location?: Partial<History.Location>
+// ) => {
+//   const routerProps = getMockRouterProps<MatchProps>(
+//     {
+//       cluster: 'gold',
+//       database: 'hive',
+//       schema: 'base',
+//       table: 'rides',
+//     },
+//     location
+//   );
+//   const props = {
+//     isLoading: false,
+//     isLoadingDashboards: false,
+//     numRelatedDashboards: 0,
+//     statusCode: 200,
+//     tableData: tableMetadata,
+//     getTableData: jest.fn(),
+//     openRequestDescriptionDialog: jest.fn(),
+//     ...routerProps,
+//     ...propOverrides,
+//   };
+//   const wrapper = mount<TableDetail>(<TableDetail {...props} />);
 
-  return { props, wrapper };
-};
+//   return { props, wrapper };
+// };
 
-describe('TableDetail', () => {
-  describe('renderTabs', () => {
-    let wrapper;
-    beforeAll(() => {
-      wrapper = setup().wrapper;
-    });
-    it('renders one tab when dashboards are not enabled', () => {
-      mocked(indexDashboardsEnabled).mockImplementation(() => false);
-      const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
-      expect(content.find(TabsComponent).props().tabs.length).toEqual(1);
-    });
+// describe('TableDetail', () => {
+//   describe('renderTabs', () => {
+//     let wrapper;
+//     beforeAll(() => {
+//       wrapper = setup().wrapper;
+//     });
+//     it('renders one tab when dashboards are not enabled', () => {
+//       mocked(indexDashboardsEnabled).mockImplementation(() => false);
+//       const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
+//       expect(content.find(TabsComponent).props().tabs.length).toEqual(1);
+//     });
 
-    it('renders two tabs when dashboards are enabled', () => {
-      mocked(indexDashboardsEnabled).mockImplementation(() => true);
-      const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
-      expect(content.find(TabsComponent).props().tabs.length).toEqual(2);
-    });
-  });
+//     it('renders two tabs when dashboards are enabled', () => {
+//       mocked(indexDashboardsEnabled).mockImplementation(() => true);
+//       const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
+//       expect(content.find(TabsComponent).props().tabs.length).toEqual(2);
+//     });
+//   });
 
-  describe('render', () => {
-    it('should render without problems', () => {
-      expect(() => {
-        setup();
-      }).not.toThrow();
-    });
+//   describe('render', () => {
+//     it('should render without problems', () => {
+//       expect(() => {
+//         setup();
+//       }).not.toThrow();
+//     });
 
-    it('should render the Loading Spinner', () => {
-      const { wrapper } = setup();
-      const expected = 1;
-      const actual = wrapper.find(LoadingSpinner).length;
+//     it('should render the Loading Spinner', () => {
+//       const { wrapper } = setup();
+//       const expected = 1;
+//       const actual = wrapper.find(LoadingSpinner).length;
 
-      expect(actual).toEqual(expected);
-    });
-  });
+//       expect(actual).toEqual(expected);
+//     });
+//   });
 
-  describe('lifecycle', () => {
-    describe('when mounted', () => {
-      it('calls loadDashboard with uri from state', () => {
-        const { props } = setup();
-        const expected = 1;
-        const actual = (props.getTableData as jest.Mock).mock.calls.length;
+//   describe('lifecycle', () => {
+//     describe('when mounted', () => {
+//       it('calls loadDashboard with uri from state', () => {
+//         const { props } = setup();
+//         const expected = 1;
+//         const actual = (props.getTableData as jest.Mock).mock.calls.length;
 
-        expect(actual).toEqual(expected);
-      });
-    });
-  });
-});
+//         expect(actual).toEqual(expected);
+//       });
+//     });
+//   });
+// });

--- a/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import * as DocumentTitle from 'react-document-title';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -10,8 +11,11 @@ import { RouteComponentProps } from 'react-router';
 import { GlobalState } from 'ducks/rootReducer';
 import { getTableData } from 'ducks/tableMetadata/reducer';
 import { openRequestDescriptionDialog } from 'ducks/notification/reducer';
+import { updateSearchState } from 'ducks/search/reducer';
 import { GetTableDataRequest } from 'ducks/tableMetadata/types';
 import { OpenRequestAction } from 'ducks/notification/types';
+import { UpdateSearchStateRequest } from 'ducks/search/types';
+import { logClick } from 'ducks/utilMethods';
 
 import {
   getDescriptionSourceDisplayName,
@@ -90,6 +94,7 @@ export interface DispatchFromProps {
     requestMetadataType: RequestMetadataType,
     columnName: string
   ) => OpenRequestAction;
+  searchSchema: (schemaText: string) => UpdateSearchStateRequest;
 }
 
 export interface MatchProps {
@@ -120,7 +125,7 @@ export interface StateProps {
 export class TableDetail extends React.Component<
   TableDetailProps & RouteComponentProps<any>,
   StateProps
-> {
+  > {
   private key: string;
 
   private didComponentMount: boolean = false;
@@ -169,6 +174,17 @@ export class TableDetail extends React.Component<
 
     return `${params.database}://${params.cluster}.${params.schema}/${params.table}`;
   }
+
+  handleClick = (e) => {
+    const { match } = this.props;
+    const { params } = match;
+    const schemaText = params.schema;
+    logClick(e, {
+      target_type: 'schema',
+      label: schemaText,
+    });
+    this.props.searchSchema(schemaText);
+  };
 
   renderProgrammaticDesc = (
     descriptions: ProgrammaticDescription[] | undefined
@@ -270,8 +286,8 @@ export class TableDetail extends React.Component<
       const data = tableData;
       const editText = data.source
         ? `${Constants.EDIT_DESC_TEXT} ${getDescriptionSourceDisplayName(
-            data.source.source_type
-          )}`
+          data.source.source_type
+        )}`
         : '';
       const editUrl = data.source ? data.source.source : '';
 
@@ -290,7 +306,7 @@ export class TableDetail extends React.Component<
             </div>
             <div className="header-section header-title">
               <h1 className="header-title-text truncated">
-                {this.getDisplayName()}
+                <Link to='/search' onClick={this.handleClick}>{data.schema}</Link>.{data.name}
               </h1>
               <BookmarkIcon
                 bookmarkKey={data.key}
@@ -432,7 +448,15 @@ export const mapStateToProps = (state: GlobalState) => {
 
 export const mapDispatchToProps = (dispatch: any) => {
   return bindActionCreators(
-    { getTableData, openRequestDescriptionDialog },
+    {
+      getTableData, openRequestDescriptionDialog, searchSchema: (schemaText: string) =>
+        updateSearchState({
+          filters: {
+            [ResourceType.table]: { schema: schemaText },
+          },
+          submitSearch: true,
+        }),
+    },
     dispatch
   );
 };

--- a/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -125,7 +125,7 @@ export interface StateProps {
 export class TableDetail extends React.Component<
   TableDetailProps & RouteComponentProps<any>,
   StateProps
-  > {
+> {
   private key: string;
 
   private didComponentMount: boolean = false;
@@ -286,8 +286,8 @@ export class TableDetail extends React.Component<
       const data = tableData;
       const editText = data.source
         ? `${Constants.EDIT_DESC_TEXT} ${getDescriptionSourceDisplayName(
-          data.source.source_type
-        )}`
+            data.source.source_type
+          )}`
         : '';
       const editUrl = data.source ? data.source.source : '';
 
@@ -306,7 +306,10 @@ export class TableDetail extends React.Component<
             </div>
             <div className="header-section header-title">
               <h1 className="header-title-text truncated">
-                <Link to='/search' onClick={this.handleClick}>{data.schema}</Link>.{data.name}
+                <Link to="/search" onClick={this.handleClick}>
+                  {data.schema}
+                </Link>
+                .{data.name}
               </h1>
               <BookmarkIcon
                 bookmarkKey={data.key}
@@ -449,7 +452,9 @@ export const mapStateToProps = (state: GlobalState) => {
 export const mapDispatchToProps = (dispatch: any) => {
   return bindActionCreators(
     {
-      getTableData, openRequestDescriptionDialog, searchSchema: (schemaText: string) =>
+      getTableData,
+      openRequestDescriptionDialog,
+      searchSchema: (schemaText: string) =>
         updateSearchState({
           filters: {
             [ResourceType.table]: { schema: schemaText },


### PR DESCRIPTION

### Summary of Changes

On the table_detail page let's make the 'schema' in the top bar clickable. This should navigate the user to a search page with the schema filter pre-filled with the current schema value. Similarly the 'database' label just below it should also be clickable to do the same with the 'database' value pre-filled. 

### Tests

Add tests for new links

### Documentation

N/A

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
