### PR TITLE
fix: (until they update urllib3) rolling back to v 0.10.15 of responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ marshmallow-annotations>=2.4.0,<3.0
 # A utility library for mocking out the requests Python library.
 # License: Apache 2.0
 # Upstream url: https://pypi.org/project/responses/
-responses==0.12.1
+responses==0.10.15
 
 # A common package that holds the models deifnition and schemas that are used
 # accross different amundsen repositories.


### PR DESCRIPTION
### Summary of Changes

Bumped responses back to version that does not pin urllib3 since it was causing conflict with other dependencies using newer versions of urllib3.

https://github.com/getsentry/responses/blob/30a7fa73e050b72432492e955faead2d37302fb6/CHANGES#L27


### Tests

N/A

### Documentation

N/A

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
