### PR TITLE
fix: fixed webpack 5 issue

### DIFF
--- a/amundsen_application/static/.storybook/webpack.config.js
+++ b/amundsen_application/static/.storybook/webpack.config.js
@@ -3,6 +3,7 @@
 
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const webpack = require('webpack');
 
 function resolve(dir) {
   return path.join(__dirname, dir);
@@ -61,7 +62,7 @@ module.exports = {
         test: FONT_PATTERN,
         use: 'file-loader',
       },
-    ]
+    ],
   },
   resolve: {
     extensions: RESOLVED_EXTENSIONS,
@@ -74,4 +75,10 @@ module.exports = {
       utils: PATHS.utils,
     },
   },
+  plugins: [
+    // fix "process is not defined" error:
+    new webpack.ProvidePlugin({
+      process: 'process/browser',
+    }),
+  ],
 };

--- a/amundsen_application/static/package-lock.json
+++ b/amundsen_application/static/package-lock.json
@@ -31028,8 +31028,7 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.0",

--- a/amundsen_application/static/package.json
+++ b/amundsen_application/static/package.json
@@ -135,6 +135,7 @@
     "jquery": "^3.5.0",
     "moment-timezone": "^0.5.31",
     "path-browserify": "^1.0.1",
+    "process": "^0.11.10",
     "react": "^16.13.1",
     "react-avatar": "^2.5.1",
     "react-bootstrap": "^0.32.4",

--- a/amundsen_application/static/webpack.common.ts
+++ b/amundsen_application/static/webpack.common.ts
@@ -128,6 +128,10 @@ const config: webpack.Configuration = {
     new CleanWebpackPlugin(),
     new MomentLocalesPlugin(), // To strip all locales except “en”
     ...htmlWebpackPluginConfig,
+    // fix "process is not defined" error:
+    new webpack.ProvidePlugin({
+      process: 'process/browser',
+    }),
   ],
   optimization: {
     moduleIds: 'deterministic',

--- a/amundsen_application/static/webpack.dev.ts
+++ b/amundsen_application/static/webpack.dev.ts
@@ -4,12 +4,18 @@ import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 
 import commonConfig from './webpack.common';
 
+const webpack = require('webpack');
+
 export default merge(commonConfig, {
   mode: 'development',
   devtool: 'inline-source-map',
   plugins: [
     new MiniCssExtractPlugin({
       filename: '[name].dev.css',
+    }),
+    // fix "process is not defined" error:
+    new webpack.ProvidePlugin({
+      process: 'process/browser',
     }),
     // new BundleAnalyzerPlugin()     // Uncomment to check the bundle size on dev
   ],

--- a/amundsen_application/static/webpack.prod.ts
+++ b/amundsen_application/static/webpack.prod.ts
@@ -3,6 +3,8 @@ import merge from 'webpack-merge';
 import TerserPlugin from 'terser-webpack-plugin';
 import commonConfig from './webpack.common';
 
+const webpack = require('webpack');
+
 export default merge(commonConfig, {
   mode: 'production',
   optimization: {
@@ -18,6 +20,10 @@ export default merge(commonConfig, {
   plugins: [
     new MiniCssExtractPlugin({
       filename: '[name].[contenthash].css',
+    }),
+    // fix "process is not defined" error:
+    new webpack.ProvidePlugin({
+      process: 'process/browser',
     }),
   ],
 });


### PR DESCRIPTION

### Summary of Changes

Followed https://stackoverflow.com/questions/41359504/webpack-bundle-js-uncaught-referenceerror-process-is-not-defined/64553486#64553486 to fix `react_devtools_backend.js:2430 ReferenceError: process is not defined`.

### Tests

N/A

### Documentation

N/A

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
