### PR TITLE
chore: print human-readable error if index.html isn't found

### DIFF
--- a/amundsen_application/api/__init__.py
+++ b/amundsen_application/api/__init__.py
@@ -2,11 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Tuple
+import logging
 
 from flask import Flask, render_template
+import jinja2
 import os
 
+
 ENVIRONMENT = os.getenv('APPLICATION_ENV', 'development')
+LOGGER = logging.getLogger(__name__)
 
 
 def init_routes(app: Flask) -> None:
@@ -16,7 +20,11 @@ def init_routes(app: Flask) -> None:
 
 
 def index(path: str) -> Any:
-    return render_template("index.html", env=ENVIRONMENT)  # pragma: no cover
+    try:
+        return render_template("index.html", env=ENVIRONMENT)  # pragma: no cover
+    except jinja2.exceptions.TemplateNotFound as e:
+        LOGGER.error("index.html template not found, have you built the front-end JS (npm run build in static/?")
+        raise e
 
 
 def healthcheck() -> Tuple[str, int]:


### PR DESCRIPTION
### Summary of Changes

Issues like https://github.com/amundsen-io/amundsen/issues/822 seem like something is going very wrong with the install, but very commonly it's just a step was missing. In that case, print a human-readable more-helpful error line.

We don't have jinja2 in our requirements -- it's from Flask, but that seems stable enough to be safe

### Tests

n/a

### Documentation

n/a

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
