### PR TITLE
fix: in search results, change header based on content

### DIFF
--- a/amundsen_application/static/js/components/common/ResourceList/ResourceListHeader/constants.ts
+++ b/amundsen_application/static/js/components/common/ResourceList/ResourceListHeader/constants.ts
@@ -3,3 +3,5 @@ export const RESOURCE_HEADER_TITLE = 'RESOURCE';
 export const SOURCE_HEADER_TITLE = 'SOURCE';
 
 export const BADGES_HEADER_TITLE = 'BADGES';
+
+export const LAST_UPDATED_HEADER_TITLE = 'LAST RUN';

--- a/amundsen_application/static/js/components/common/ResourceList/ResourceListHeader/index.tsx
+++ b/amundsen_application/static/js/components/common/ResourceList/ResourceListHeader/index.tsx
@@ -5,13 +5,32 @@ import * as React from 'react';
 
 import './styles.scss';
 
+import { ResourceType } from 'interfaces';
 import {
   RESOURCE_HEADER_TITLE,
   SOURCE_HEADER_TITLE,
   BADGES_HEADER_TITLE,
+  LAST_UPDATED_HEADER_TITLE,
 } from './constants';
 
-const ResourceListHeader: React.FC = () => {
+export interface ResourceListHeaderProps {
+  resourceTypes: ResourceType[];
+}
+
+const contentHeaderTitle = (type: ResourceType): string => {
+  switch (type) {
+    case ResourceType.dashboard:
+      return LAST_UPDATED_HEADER_TITLE;
+
+    default:
+      return BADGES_HEADER_TITLE;
+  }
+};
+const ResourceListHeader: React.FC<ResourceListHeaderProps> = ({
+  resourceTypes,
+}: ResourceListHeaderProps) => {
+  const contentHeader =
+    resourceTypes.length === 1 ? contentHeaderTitle(resourceTypes[0]) : '';
   return (
     <div className="resource-list-header">
       <span className="resource">
@@ -19,7 +38,7 @@ const ResourceListHeader: React.FC = () => {
       </span>
       <span className="source">{SOURCE_HEADER_TITLE}</span>
       <span className="badges">
-        <span className="badges-text">{BADGES_HEADER_TITLE}</span>
+        <span className="badges-text">{contentHeader}</span>
       </span>
     </div>
   );

--- a/amundsen_application/static/js/pages/SearchPage/index.tsx
+++ b/amundsen_application/static/js/pages/SearchPage/index.tsx
@@ -145,9 +145,13 @@ export class SearchPage extends React.Component<SearchPageProps> {
       );
     }
 
+    const uniqueResourceTypes = [
+      ...new Set(results.results.map(({ type }) => type)),
+    ];
+
     return (
       <div className="search-list-container">
-        <ResourceListHeader />
+        <ResourceListHeader resourceTypes={uniqueResourceTypes} />
         <PaginatedApiResourceList
           activePage={page_index}
           onPagination={this.props.setPageIndex}


### PR DESCRIPTION
### Summary of Changes

When searching, `ResourceListItem` uses per-resource content classes to sub in the content columns. Thus the header columns need to vary based on the content as well.

Solve that by having the parent of `ResourceListHeader` pass in the types of the current content, and have `ResourceListHeader` swap out labels based on `ResourceType`

It's a bit smelly to me to have a fan-out based on `ResourceType` here. Perhaps ideally `Resource` would have a `columnLabel` method, and `DashboardResource` would override that to show the correct label (same for other subclasses of `Resources`). however AFAICT `DashboardResource` is just an interface, not an object, so I don't know that that's possible. Definitely looking for a better way to do this, this certainly works and isn't horrific, but it is a bit fragile. I've defaulted to just show BADGES (as before) so that if a new resource type is added, a label will be shown by default. If there are multiple different resource types passed in, we'll just display a blank column header.

### Tests

I don't know how to test this behavior, but would be happy to add test if pointed to a somewhat-similar example.

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
