### PR TITLE
chore: add dorian to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,9 +11,9 @@
 *       @amundsen-io/amundsen-committers
 
 # Frontend Files
-/amundsen_application/static/    @Golodhros @ttannis @allisonsuarez @dikshathakur3119 @feng-tao
+/amundsen_application/static/    @Golodhros @ttannis @allisonsuarez @dikshathakur3119 @feng-tao @dorianj
 
 # Backend Files
-*.py    @ttannis @feng-tao @dikshathakur3119 @allisonsuarez
-/amundsen_application/api/    @ttannis @feng-tao @dikshathakur3119 @allisonsuarez
-/amundsen_application/models/    @ttannis @feng-tao @dikshathakur3119 @allisonsuarez
+*.py    @ttannis @feng-tao @dikshathakur3119 @allisonsuarez @dorianj
+/amundsen_application/api/    @ttannis @feng-tao @dikshathakur3119 @allisonsuarez @dorianj
+/amundsen_application/models/    @ttannis @feng-tao @dikshathakur3119 @allisonsuarez @dorianj


### PR DESCRIPTION
I mostly want to approve dependabot PRs right right now.

I'll start reviewing other code as well but would like a second set of 👀 before I start merging alone