### PR TITLE
fix: Set sender when sending feedback

### DIFF
--- a/amundsen_application/api/mail/v0.py
+++ b/amundsen_application/api/mail/v0.py
@@ -53,7 +53,10 @@ def feedback() -> Response:
             'form_data': data
         }
 
-        response = mail_client.send_email(html=html_content, subject=subject, optional_data=options)
+        # Get sender of the feedback.
+        sender = app.config['AUTH_USER_METHOD'](app).email
+
+        response = mail_client.send_email(html=html_content, subject=subject, optional_data=options, sender=sender)
         status_code = response.status_code
 
         if 200 <= status_code < 300:

--- a/tests/unit/api/mail/test_v0.py
+++ b/tests/unit/api/mail/test_v0.py
@@ -112,6 +112,7 @@ class MailTest(unittest.TestCase):
                 'notificationType': test_notification_type,
                 'options': test_options,
             })
+
             send_notification_mock.assert_called_with(
                 notification_type=test_notification_type,
                 options=test_options,


### PR DESCRIPTION
Signed-off-by: JacobSMoller <scherffenberg91@gmail.com>
### Summary of Changes

Sets the sender to current user, same style as its done for notifications. 

### Tests

Don't see any use in testing if the flask functionality works. 

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
