### PR TITLE
fix: pyarrow dependency breaking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -71,9 +71,6 @@ responses==0.12.1
 # Required for announcement client
 SQLAlchemy==1.3.22
 
-# Required for Dremio preview client
-pyarrow<2.0.0
-
 # A common package that holds the models deifnition and schemas that are used
 # accross different amundsen repositories.
 amundsen-common==0.5.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ responses==0.12.1
 SQLAlchemy==1.3.22
 
 # Required for Dremio preview client
-pyarrow==2.0.0
+pyarrow<2.0.0
 
 # A common package that holds the models deifnition and schemas that are used
 # accross different amundsen repositories.

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     dependency_links=[],
+    setup_requires=['cython >= 0.29'],
     install_requires=requirements,
     extras_require={
         'oidc': ['flaskoidc==0.1.1']

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(
     setup_requires=['cython >= 0.29'],
     install_requires=requirements,
     extras_require={
-        'oidc': ['flaskoidc==0.1.1']
+        'oidc': ['flaskoidc==0.1.1'],
+        'pyarrow': ['pyarrow==2.0.0'],
     },
     python_requires=">=3.6",
     entry_points="""


### PR DESCRIPTION
### Summary of Changes

pyarrow depenency failed because of a ModuleNotFoundError: No module named 'Cython'. Added it as an extra requirement on setup.py

### Tests

N/A

### Documentation

N/A

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
