### PR TITLE
fix: Add cluster to preview data query 

### DIFF
--- a/amundsen_application/static/js/ducks/tableMetadata/index.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/index.spec.ts
@@ -117,6 +117,7 @@ describe('tableMetadata ducks', () => {
       database: 'testDb',
       schema: 'testSchema',
       tableName: 'testName',
+      cluster: 'testCluster',
     };
   });
 

--- a/amundsen_application/static/js/interfaces/TableMetadata.ts
+++ b/amundsen_application/static/js/interfaces/TableMetadata.ts
@@ -48,6 +48,7 @@ export interface PreviewQueryParams {
   database: string;
   schema: string;
   tableName: string;
+  cluster: string;
 }
 
 export interface PreviewData {

--- a/amundsen_application/static/js/pages/TableDetailPage/DataPreviewButton/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/DataPreviewButton/index.tsx
@@ -87,6 +87,7 @@ export class DataPreviewButton extends React.Component<
       database: tableData.database,
       schema: tableData.schema,
       tableName: tableData.name,
+      cluster: tableData.cluster,
     });
   }
 


### PR DESCRIPTION
### Summary of Changes

Adds the table cluster to the preview query params, so it can be used when making a preview client. 
useful e.g. for Bigquery tables, where the Google Cloud Project id(The cluster) is needed to query a table for preview data. 

### Tests

Unsure where to add tests for this. :) Also not sure the change warrants a test. 

### Documentation

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
