### PR TITLE
bug: remove duplicated env var fetch

### DIFF
--- a/amundsen_application/__init__.py
+++ b/amundsen_application/__init__.py
@@ -36,7 +36,7 @@ STATIC_ROOT = os.getenv('STATIC_ROOT', 'static')
 static_dir = os.path.join(PROJECT_ROOT, STATIC_ROOT)
 
 
-def create_app(config_module_class: str, template_folder: str = None) -> Flask:
+def create_app(config_module_class: str = None, template_folder: str = None) -> Flask:
     """ Support for importing arguments for a subclass of flask.Flask """
     args = ast.literal_eval(os.getenv('APP_WRAPPER_ARGS', '')) if os.getenv('APP_WRAPPER_ARGS') else {}
 
@@ -44,6 +44,9 @@ def create_app(config_module_class: str, template_folder: str = None) -> Flask:
     app = app_wrapper_class(__name__, static_folder=static_dir, template_folder=tmpl_dir, **args)
 
     # Support for importing a custom config class
+    if not config_module_class:
+        config_module_class = os.getenv('FRONTEND_SVC_CONFIG_MODULE_CLASS')
+
     app.config.from_object(config_module_class)
 
     if app.config.get('LOG_CONFIG_FILE'):

--- a/amundsen_application/__init__.py
+++ b/amundsen_application/__init__.py
@@ -43,10 +43,7 @@ def create_app(config_module_class: str, template_folder: str = None) -> Flask:
     tmpl_dir = template_folder if template_folder else os.path.join(PROJECT_ROOT, static_dir, 'dist/templates')
     app = app_wrapper_class(__name__, static_folder=static_dir, template_folder=tmpl_dir, **args)
 
-    """ Support for importing a custom config class """
-    config_module_class = \
-        os.getenv('FRONTEND_SVC_CONFIG_MODULE_CLASS') or config_module_class
-
+    # Support for importing a custom config class
     app.config.from_object(config_module_class)
 
     if app.config.get('LOG_CONFIG_FILE'):

--- a/amundsen_application/wsgi.py
+++ b/amundsen_application/wsgi.py
@@ -4,8 +4,11 @@
 import os
 from amundsen_application import create_app
 
-application = create_app(
-    config_module_class=os.getenv('FRONTEND_SVC_CONFIG_MODULE_CLASS') or 'amundsen_application.config.LocalConfig')
+
+if not os.getenv('FRONTEND_SVC_CONFIG_MODULE_CLASS'):
+    os.environ['FRONTEND_SVC_CONFIG_MODULE_CLASS'] = 'amundsen_application.config.TestConfig'
+
+application = create_app()
 
 if __name__ == '__main__':
     application.run(host='0.0.0.0')


### PR DESCRIPTION
In `wsgi.py`, we do:
```
application = create_app(
    config_module_class=os.getenv('FRONTEND_SVC_CONFIG_MODULE_CLASS') or 'amundsen_application.config.LocalConfig')
```

So this check of env vars inside `create_app` was duplicated. This is problematic if you use a custom `create_app` invocation, and then accidentally have a `FRONTEND_SVC_CONFIG_MODULE_CLASS` env var present. It might be reasonable to have `create_app` use the env var iff `config_module_class` isn't set (i'm happy to change PR to do that), which I think is more in line with expectations of default vars.

### Tests

Ran frontend with custom `FRONTEND_SVC_CONFIG_MODULE_CLASS` set, it's picked up.


(ty for @madison-ookla for noticing this irregularity)
