### PR TITLE
fix: Properly render html markdown for programmatic descriptions

### DIFF
--- a/amundsen_application/static/js/components/EditableText/index.tsx
+++ b/amundsen_application/static/js/components/EditableText/index.tsx
@@ -125,7 +125,7 @@ class EditableText extends React.Component<
       return (
         <div className="editable-text">
           <div className="markdown-wrapper">
-            <ReactMarkdown allowDangerousHtml={true}>{value}</ReactMarkdown>
+            <ReactMarkdown allowDangerousHtml>{value}</ReactMarkdown>
           </div>
           {editable && !value && (
             <a

--- a/amundsen_application/static/js/components/EditableText/index.tsx
+++ b/amundsen_application/static/js/components/EditableText/index.tsx
@@ -125,7 +125,7 @@ class EditableText extends React.Component<
       return (
         <div className="editable-text">
           <div className="markdown-wrapper">
-            <ReactMarkdown allowDangerousHtml={false}>{value}</ReactMarkdown>
+            <ReactMarkdown allowDangerousHtml={true}>{value}</ReactMarkdown>
           </div>
           {editable && !value && (
             <a


### PR DESCRIPTION
### Summary of Changes
Programmatic descriptions were rendering raw html instead of rendered html. This PR makes sure markdown with html tags like <img /> renders the html, in this example the image. For example, at Lyft, we use programmatic descriptions with <img > to 
Before fix
![image](https://user-images.githubusercontent.com/6227867/113793347-e3a37f00-96fc-11eb-91f5-d943fd315628.png)

After fix
![image](https://user-images.githubusercontent.com/6227867/113793750-e0f55980-96fd-11eb-9f55-5e9df7e49678.png)

@danwom and @allisonsuarez confirm there is no possibility of malicious injection through this component

### Tests
No tests modified - this aspect of programmatic descriptions was not covered in tests

### Documentation
None