### PR TITLE
fix: Display watermarks for all tables when available

### DIFF
--- a/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -423,14 +423,12 @@ export class TableDetail extends React.Component<
                       </time>
                     </section>
                   )}
-                  {
-                    <section className="metadata-section">
-                      <div className="section-title">
-                        {Constants.DATE_RANGE_TITLE}
-                      </div>
-                      <WatermarkLabel watermarks={data.watermarks} />
-                    </section>
-                  }
+                  <section className="metadata-section">
+                    <div className="section-title">
+                      {Constants.DATE_RANGE_TITLE}
+                    </div>
+                    <WatermarkLabel watermarks={data.watermarks} />
+                  </section>
                   <EditableSection title={Constants.TAG_TITLE}>
                     <TagInput
                       resourceType={ResourceType.table}

--- a/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -423,14 +423,14 @@ export class TableDetail extends React.Component<
                       </time>
                     </section>
                   )}
-                  {!data.is_view && (
+                  {
                     <section className="metadata-section">
                       <div className="section-title">
                         {Constants.DATE_RANGE_TITLE}
                       </div>
                       <WatermarkLabel watermarks={data.watermarks} />
                     </section>
-                  )}
+                  }
                   <EditableSection title={Constants.TAG_TITLE}>
                     <TagInput
                       resourceType={ResourceType.table}


### PR DESCRIPTION
This PR addresses issue: https://github.com/amundsen-io/amundsen/issues/997

### Summary of Changes

Previously watermarks were only shown for tables that are not views. This removes the validation in the front-end. 

If showing watermarks for views is _absolutely_ required, or if there needs to be more complex logic handling when to show this, the logic can be to move this validation into the metadata service in the future to only return results for eligible tables.

### Tests

No tests added / updated

### Documentation

N/A

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
