### PR TITLE
docs: FLASK session SECRET KEY is not same as client secret

### DIFF
--- a/public.Dockerfile
+++ b/public.Dockerfile
@@ -32,7 +32,7 @@ ENV SQLALCHEMY_DATABASE_URI sqlite:///sessions.db
 
 # You will need to set these environment variables in order to use the oidc image
 # OIDC_CLIENT_SECRETS - a path to a client_secrets.json file
-# FLASK_OIDC_SECRET_KEY - A secret key from your oidc provider
+# SECRET_KEY - A secret key used to secure session storage in FLASK.
 # You will also need to mount a volume for the clients_secrets.json file.
 
 FROM base as release


### PR DESCRIPTION
This comment in `public.Dockerfile` confuses two concepts: 
> FLASK_OIDC_SECRET_KEY - A secret key from your oidc provider

1. The client secret from your OIDC provider. This should come in the `client_secrets.json` and is covered by the comment for `OIDC_CLIENT_SECRETS `.
2. The flask SECRET KEY, which is used for storing session storage. https://flask.palletsprojects.com/en/1.1.x/config/#SECRET_KEY. This should be passed to FLASK through `SECRET_KEY`, not `FLASK_OIDC_SECRET_KEY`. This has nothing to do with your OIDC provider.

This patch makes it clear that the second concept is the one we want for this comment.
